### PR TITLE
Interface pipeline methods

### DIFF
--- a/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
@@ -27,7 +27,7 @@ internal interface IPipelineSettings
     bool CopyAttributes { get; }
     Predicate<string>? CopyInterfacePredicate { get; }
     bool CopyInterfaces { get; }
-    Predicate<IMethod>? CopyMethodPredicate { get; }
+    Func<IType, IMethod, bool>? CopyMethodPredicate { get; }
     bool CopyMethods { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }

--- a/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
@@ -29,6 +29,7 @@ internal interface IPipelineSettings
     bool CopyInterfaces { get; }
     Func<IType, IMethod, bool>? CopyMethodPredicate { get; }
     bool CopyMethods { get; }
+    bool InheritFromInterfaces { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }
     bool CreateRecord { get; }

--- a/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration.Bootstrap/Models/Pipelines/IPipelineSettings.cs
@@ -27,6 +27,8 @@ internal interface IPipelineSettings
     bool CopyAttributes { get; }
     Predicate<string>? CopyInterfacePredicate { get; }
     bool CopyInterfaces { get; }
+    Predicate<IMethod>? CopyMethodPredicate { get; }
+    bool CopyMethods { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }
     bool CreateRecord { get; }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
@@ -7,7 +7,7 @@ public class AbstractEntities : ClassFrameworkCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetAbstractModels(), "ClassFramework.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetAbstractModels(), "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
@@ -7,7 +7,7 @@ public class AbstractionsInterfaces : ClassFrameworkCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetInterfaces(GetAbstractionsInterfaces(), "ClassFramework.Domain.Abstractions");
+    public override IEnumerable<TypeBase> Model => GetEntityInterfaces(GetAbstractionsInterfaces(), "ClassFramework.Domain", "ClassFramework.Domain.Abstractions");
 
     public override string Path => "ClassFramework.Domain/Abstractions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
@@ -13,7 +13,7 @@ public abstract class ClassFrameworkCSharpClassBase : CsharpClassGeneratorPipeli
     public override Encoding Encoding => Encoding.UTF8;
 
     protected override Type EntityCollectionType => typeof(IReadOnlyCollection<>);
-    protected override Type EntityConcreteCollectionType => typeof(List<>);
+    protected override Type EntityConcreteCollectionType => typeof(ReadOnlyValueCollection<>);
     protected override Type BuilderCollectionType => typeof(List<>);
 
     protected override string ProjectName => "ClassFramework";
@@ -21,6 +21,7 @@ public abstract class ClassFrameworkCSharpClassBase : CsharpClassGeneratorPipeli
     protected override string CoreNamespace => "ClassFramework.Domain";
     protected override bool CopyAttributes => true;
     protected override bool CopyInterfaces => true;
+    protected override bool CreateRecord => true;
     //protected override string ToBuilderFormatString => string.Empty;
     //protected override string ToTypedBuilderFormatString => string.Empty;
     //protected override bool AddCopyConstructor => false;

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
@@ -7,7 +7,7 @@ public class CoreEntities : ClassFrameworkCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetCoreModels(), "ClassFramework.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
@@ -13,5 +13,5 @@ public class OverrideCodeStatementEntities : ClassFrameworkCSharpClassBase
     protected override Class? BaseClass => CreateBaseclass(typeof(ICodeStatementBase), "ClassFramework.Domain");
 
     public override IEnumerable<TypeBase> Model
-        => GetImmutableClasses(GetOverrideModels(typeof(ICodeStatementBase)), "ClassFramework.Domain.CodeStatements");
+        => GetEntities(GetOverrideModels(typeof(ICodeStatementBase)), "ClassFramework.Domain.CodeStatements");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -13,5 +13,5 @@ public class OverrideTypeEntities : ClassFrameworkCSharpClassBase
     protected override Class? BaseClass => CreateBaseclass(typeof(ITypeBase), "ClassFramework.Domain");
 
     public override IEnumerable<TypeBase> Model
-        => GetImmutableClasses(GetOverrideModels(typeof(ITypeBase)), "ClassFramework.Domain.Types");
+        => GetEntities(GetOverrideModels(typeof(ITypeBase)), "ClassFramework.Domain.Types");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
@@ -7,7 +7,7 @@ public class PipelineEntities : ClassFrameworkCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetPipelineModels(), "ClassFramework.Pipelines");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetPipelineModels(), "ClassFramework.Pipelines");
 
     public override string Path => "ClassFramework.Pipelines";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -7,7 +7,7 @@ public class TemplateFrameworkEntities : ClassFrameworkCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.CodeGeneration/GlobalUsings.cs
+++ b/src/ClassFramework.CodeGeneration/GlobalUsings.cs
@@ -23,6 +23,7 @@ global using ClassFramework.Pipelines.OverrideEntity;
 global using ClassFramework.Pipelines.Reflection;
 global using ClassFramework.TemplateFramework.CodeGenerationProviders;
 global using ClassFramework.TemplateFramework.Extensions;
+global using CrossCutting.Common;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.ProcessingPipeline;
 global using CrossCutting.Utilities.Parsers.Extensions;

--- a/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
@@ -27,7 +27,7 @@ internal interface IPipelineSettings
     bool CopyAttributes { get; }
     Predicate<string>? CopyInterfacePredicate { get; }
     bool CopyInterfaces { get; }
-    Predicate<IMethod>? CopyMethodPredicate { get; }
+    Func<IType, IMethod, bool>? CopyMethodPredicate { get; }
     bool CopyMethods { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }

--- a/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
@@ -58,6 +58,6 @@ internal interface IPipelineSettings
     [Required]IReadOnlyCollection<ITypenameMapping> TypenameMappings { get; }
     bool UseBaseClassFromSourceModel { get; }
     bool UseExceptionThrowIfNull { get; }
-    Domains.ArgumentValidationType ValidateArguments { get; }
-    Domains.ArgumentValidationType OriginalValidateArguments { get; }
+    ArgumentValidationType ValidateArguments { get; }
+    ArgumentValidationType OriginalValidateArguments { get; }
 }

--- a/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
@@ -29,6 +29,7 @@ internal interface IPipelineSettings
     bool CopyInterfaces { get; }
     Func<IType, IMethod, bool>? CopyMethodPredicate { get; }
     bool CopyMethods { get; }
+    bool InheritFromInterfaces { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }
     bool CreateRecord { get; }

--- a/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
+++ b/src/ClassFramework.CodeGeneration/Models/Pipelines/IPipelineSettings.cs
@@ -27,6 +27,8 @@ internal interface IPipelineSettings
     bool CopyAttributes { get; }
     Predicate<string>? CopyInterfacePredicate { get; }
     bool CopyInterfaces { get; }
+    Predicate<IMethod>? CopyMethodPredicate { get; }
+    bool CopyMethods { get; }
     bool CreateAsObservable { get; }
     bool CreateConstructors { get; }
     bool CreateRecord { get; }

--- a/src/ClassFramework.Domain.Tests/TestFixtures/MyTestEntity.cs
+++ b/src/ClassFramework.Domain.Tests/TestFixtures/MyTestEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Domain.Tests.TestFixtures;
 
-public record TestValidatable : System.ComponentModel.DataAnnotations.IValidatableObject
+public record TestValidatable : IValidatableObject
 {
     public TestValidatable(int property)
     {
@@ -9,8 +9,8 @@ public record TestValidatable : System.ComponentModel.DataAnnotations.IValidatab
         /// System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
 
         // Convert validation exception to ArgumentException, for more DDD style validation:
-        var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this), results, true);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(this, new ValidationContext(this), results, true);
         var error = results.Find(x => !string.IsNullOrEmpty(x.ErrorMessage) && x.MemberNames.Any());
         if (error is not null)
         {
@@ -35,8 +35,8 @@ public class TestValidatableBuilder : IValidatableObject
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         var instance = new TestValidatable(Property);
-        var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance), results, true);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(instance, new ValidationContext(instance), results, true);
         return results;
     }
 }
@@ -56,7 +56,7 @@ public partial record MyCustomEntity
     // When using validation with IValidatableObject interface:
     protected void Validate()
     {
-        System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        Validator.ValidateObject(this, new ValidationContext(this, null, null), true);
     }
 
     // When using domain driven style validation (just throw argument exceptions), use this:
@@ -89,7 +89,7 @@ public partial record MyTestEntity
     // When using validation with IValidatableObject interface:
     protected void Validate()
     {
-        System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        Validator.ValidateObject(this, new ValidationContext(this, null, null), true);
     }
 
     // When using domain driven style validation (just throw argument exceptions), use this:
@@ -121,7 +121,7 @@ public partial class MyTestEntityBuilder ///: System.ComponentModel.DataAnnotati
         }
         set
         {
-            System.ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(value);
             _property2 = value;
         }
     }

--- a/src/ClassFramework.Pipelines.Tests/Builder/Features/AddDefaultConstructorFeatureTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Builder/Features/AddDefaultConstructorFeatureTests.cs
@@ -330,7 +330,7 @@ public class AddDefaultConstructorFeatureTests : TestBase<Pipelines.Builder.Feat
             model.Constructors.Should().ContainSingle();
             var ctor = model.Constructors.Single();
             ctor.CodeStatements.Should().AllBeOfType<StringCodeStatementBuilder>();
-            ctor.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo("Filter = default(ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder)!;", "SetDefaultValues();");
+            ctor.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo("Filter = new ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder();", "SetDefaultValues();");
         }
 
         [Fact]

--- a/src/ClassFramework.Pipelines.Tests/BuilderExtension/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/BuilderExtension/PipelineBuilderTests.cs
@@ -1,0 +1,116 @@
+﻿namespace ClassFramework.Pipelines.Tests.BuilderExtension;
+
+public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<IConcreteTypeBuilder, BuilderExtensionContext>>
+{
+    public class Constructor : PipelineBuilderTests
+    {
+        [Fact]
+        public void Allows_Altering_Existing_Pipeline()
+        {
+            // Arrange
+            var sharedFeatureBuilders = Scope!.ServiceProvider.GetServices<ISharedFeatureBuilder>();
+            var builderExtensionFeatureBuilders = Scope.ServiceProvider.GetServices<IBuilderExtensionFeatureBuilder>();
+
+            // Act
+            var pipeline = new Pipelines.BuilderExtension.PipelineBuilder(sharedFeatureBuilders, builderExtensionFeatureBuilders)
+                .With(x => x.Features.Clear())
+                .Build();
+
+            // Assert
+            pipeline.Features.Should().BeEmpty();
+        }
+    }
+
+    public class Process : PipelineBuilderTests
+    {
+        private BuilderExtensionContext CreateContext(bool addProperties = true)
+            => new BuilderExtensionContext
+            (
+                CreateGenericModel(addProperties),
+                CreateSettingsForBuilder
+                (
+                    builderNamespaceFormatString: "{Namespace}.Builders",
+                    allowGenerationWithoutProperties: false,
+                    copyAttributes: true
+                ).Build(),
+                CultureInfo.InvariantCulture
+            );
+
+        private ClassBuilder Model { get; } = new();
+
+        [Fact]
+        public void Sets_Partial()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext());
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Partial.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Adds_Fluent_Method_For_NonCollection_Property()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext());
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Methods.Where(x => x.Name == "WithProperty1").Should().ContainSingle();
+            var method = result.Value.Methods.Single(x => x.Name == "WithProperty1");
+            method.ReturnTypeName.Should().Be("T");
+            method.CodeStatements.Should().AllBeOfType<StringCodeStatementBuilder>();
+            method.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo("instance.Property1 = property1;", "return instance;");
+
+            result.Value.Methods.Where(x => x.Name == "WithProperty2").Should().BeEmpty(); //only for the non-collection property
+        }
+
+        [Fact]
+        public void Adds_Fluent_Method_For_Collection_Property()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext());
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            var methods = result.Value!.Methods.Where(x => x.Name == "AddProperty2");
+            methods.Where(x => x.Name == "AddProperty2").Should().HaveCount(2);
+            methods.Select(x => x.ReturnTypeName).Should().AllBeEquivalentTo("T");
+            methods.SelectMany(x => x.Parameters.Select(y => y.TypeName)).Should().BeEquivalentTo("T", "System.Collections.Generic.IEnumerable<System.String>", "T", "System.String[]");
+            methods.SelectMany(x => x.CodeStatements).Should().AllBeOfType<StringCodeStatementBuilder>();
+            methods.SelectMany(x => x.CodeStatements).OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo
+            (
+                "return instance.AddProperty2<T>(property2.ToArray());",
+                "foreach (var item in property2) instance.Property2.Add(item);",
+                "return instance;"
+            );
+        }
+
+        [Fact]
+        public void Returns_Invalid_When_SourceModel_Does_Not_Have_Properties_And_AllowGenerationWithoutProperties_Is_False()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext(addProperties: false));
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Invalid);
+            result.ErrorMessage.Should().Be("To create a builder extensions class, there must be at least one property");
+        }
+    }
+}

--- a/src/ClassFramework.Pipelines.Tests/Extensions/StringExtensionsTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Extensions/StringExtensionsTests.cs
@@ -10,8 +10,36 @@ public class StringExtensionsTests
         public void Throws_On_Null_Settings()
         {
             // Act & Assert
-            TypeName.Invoking(x => x.MapTypeName(settings: null!, string.Empty))
+            TypeName.Invoking(x => x.MapTypeName(settings: null!))
                     .Should().Throw<ArgumentNullException>().WithParameterName("settings");
+        }
+
+        [Fact]
+        public void Throws_On_Null_NewCollectionTypeName()
+        {
+            // Arrange
+            var settings = new PipelineSettingsBuilder()
+                .AddNamespaceMappings(new NamespaceMappingBuilder().WithSourceNamespace("MyNamespace").WithTargetNamespace("MappedNamespace"))
+                .Build();
+
+
+            // Act & Assert
+            TypeName.Invoking(x => x.MapTypeName(settings, newCollectionTypeName: null!))
+                    .Should().Throw<ArgumentNullException>().WithParameterName("newCollectionTypeName");
+        }
+
+        [Fact]
+        public void Throws_On_Null_AlternateTypeMetadataName()
+        {
+            // Arrange
+            var settings = new PipelineSettingsBuilder()
+                .AddNamespaceMappings(new NamespaceMappingBuilder().WithSourceNamespace("MyNamespace").WithTargetNamespace("MappedNamespace"))
+                .Build();
+
+
+            // Act & Assert
+            TypeName.Invoking(x => x.MapTypeName(settings, alternateTypeMetadataName: null!))
+                    .Should().Throw<ArgumentNullException>().WithParameterName("alternateTypeMetadataName");
         }
 
         [Fact]
@@ -24,7 +52,7 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = collectionTypeName.MapTypeName(settings, string.Empty);
+            var result = collectionTypeName.MapTypeName(settings);
 
             // Assert
             result.Should().Be("System.Collections.Generic.IEnumerable<MappedNamespace.MyClass>");
@@ -55,7 +83,7 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = TypeName.MapTypeName(settings, string.Empty);
+            var result = TypeName.MapTypeName(settings);
 
             // Assert
             result.Should().Be("MappedNamespace.MyClass");
@@ -70,10 +98,59 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = TypeName.MapTypeName(settings, string.Empty);
+            var result = TypeName.MapTypeName(settings);
 
             // Assert
             result.Should().Be("MappedNamespace.MappedClass");
+        }
+
+        [Fact]
+        public void Maps_SingleType_Correctly_Using_TypenameMapping_With_AlternateMetadataName_When_Not_Found()
+        {
+            // Arrange
+            var settings = new PipelineSettingsBuilder()
+                .WithInheritFromInterfaces()
+                .AddTypenameMappings(new TypenameMappingBuilder().WithSourceTypeName("MyNamespace.MyClass").WithTargetTypeName("MappedNamespace.MappedClass"))
+                .Build();
+
+            // Act
+            var result = TypeName.MapTypeName(settings, alternateTypeMetadataName: "NonExistingName");
+
+            // Assert
+            result.Should().Be("MappedNamespace.MappedClass");
+        }
+
+        [Fact]
+        public void Maps_SingleType_Correctly_Using_TypenameMapping_With_AlternateMetadataName_When_Found_But_Empty()
+        {
+            // Arrange
+            var settings = new PipelineSettingsBuilder()
+                .WithInheritFromInterfaces()
+                .AddTypenameMappings(new TypenameMappingBuilder().WithSourceTypeName("MyNamespace.MyClass").WithTargetTypeName("MappedNamespace.MappedClass").AddMetadata(new MetadataBuilder().WithName("MyName")))
+                .Build();
+
+            // Act
+            var result = TypeName.MapTypeName(settings, alternateTypeMetadataName: "MyName");
+
+            // Assert
+            result.Should().Be("MappedNamespace.MappedClass");
+        }
+
+
+        [Fact]
+        public void Maps_SingleType_Correctly_Using_TypenameMapping_With_AlternateMetadataName_When_Found_And_Not_Empty()
+        {
+            // Arrange
+            var settings = new PipelineSettingsBuilder()
+                .WithInheritFromInterfaces()
+                .AddTypenameMappings(new TypenameMappingBuilder().WithSourceTypeName("MyNamespace.MyClass").WithTargetTypeName("MappedNamespace.MappedClass").AddMetadata(new MetadataBuilder().WithName("MyName").WithValue("MappedNamespace.CustomMappedClass")))
+                .Build();
+
+            // Act
+            var result = TypeName.MapTypeName(settings, alternateTypeMetadataName: "MyName");
+
+            // Assert
+            result.Should().Be("MappedNamespace.CustomMappedClass");
         }
 
         [Fact]
@@ -85,7 +162,7 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = $"System.Func<{TypeName}>".MapTypeName(settings, string.Empty);
+            var result = $"System.Func<{TypeName}>".MapTypeName(settings);
 
             // Assert
             result.Should().Be("System.Func<MappedNamespace.MyClass>");
@@ -100,7 +177,7 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = $"System.Func<{TypeName}>".MapTypeName(settings, string.Empty);
+            var result = $"System.Func<{TypeName}>".MapTypeName(settings);
 
             // Assert
             result.Should().Be("System.Func<MappedNamespace.MappedClass>");
@@ -117,7 +194,7 @@ public class StringExtensionsTests
 
             // Act
             // note that you have to use <x,y> instead of <x, y> else we think it's a fully qualified typename! e.g. System.String, blablabla
-            var result = $"System.Func<{TypeName},MyNamespace.MySecondClass>".MapTypeName(settings, string.Empty);
+            var result = $"System.Func<{TypeName},MyNamespace.MySecondClass>".MapTypeName(settings);
 
             // Assert
             result.Should().Be("System.Func<MappedNamespace.MappedClass,MappedNamespace.MappedSecondClass>");
@@ -133,7 +210,7 @@ public class StringExtensionsTests
                 .Build();
 
             // Act
-            var result = TypeName.MapTypeName(settings, string.Empty);
+            var result = TypeName.MapTypeName(settings);
 
             // Assert
             result.Should().Be(TypeName);

--- a/src/ClassFramework.Pipelines.Tests/GlobalUsings.cs
+++ b/src/ClassFramework.Pipelines.Tests/GlobalUsings.cs
@@ -21,6 +21,8 @@ global using ClassFramework.Pipelines.Abstractions;
 global using ClassFramework.Pipelines.Builder;
 global using ClassFramework.Pipelines.Builder.Features.Abstractions;
 global using ClassFramework.Pipelines.Builder.PlaceholderProcessors;
+global using ClassFramework.Pipelines.BuilderExtension;
+global using ClassFramework.Pipelines.BuilderExtension.Features.Abstractions;
 global using ClassFramework.Pipelines.Builders;
 global using ClassFramework.Pipelines.Domains;
 global using ClassFramework.Pipelines.Entity;

--- a/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
@@ -50,6 +50,21 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
         }
 
         [Fact]
+        public void Adds_Methods()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext());
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Methods.Should().ContainSingle();
+        }
+
+        [Fact]
         public void Returns_Invalid_When_SourceModel_Does_Not_Have_Properties_And_AllowGenerationWithoutProperties_Is_False()
         {
             // Arrange

--- a/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
@@ -4,12 +4,14 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
 {
     public class Process : PipelineBuilderTests
     {
-        private InterfaceContext CreateContext(bool addProperties = true) => new InterfaceContext
+        private InterfaceContext CreateContext(bool addProperties = true, bool copyMethods = true, Predicate<Method>? copyMethodPredicate = null) => new InterfaceContext
         (
             CreateInterfaceModel(addProperties),
             CreateSettingsForInterface
             (
-                allowGenerationWithoutProperties: false
+                allowGenerationWithoutProperties: false,
+                copyMethods: copyMethods,
+                copyMethodPredicate: copyMethodPredicate
             ).Build(),
             CultureInfo.InvariantCulture
         );
@@ -50,7 +52,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
         }
 
         [Fact]
-        public void Adds_Methods()
+        public void Adds_Methods_When_CopyMethods_Is_Set_To_True()
         {
             // Arrange
             var sut = CreateSut().Build();
@@ -62,6 +64,51 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
             result.Status.Should().Be(ResultStatus.Ok);
             result.Value.Should().NotBeNull();
             result.Value!.Methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Adds_FilteredMethods_When_CopyMethods_Is_Set_To_True()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext(copyMethodPredicate: _ => true));
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Adds_FilteredMethods_When_CopyMethods_Is_Set_To_True_Negative()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext(copyMethodPredicate: _ => false));
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Methods.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Does_Not_Add_Methods_When_CopyMethods_Is_Set_To_False()
+        {
+            // Arrange
+            var sut = CreateSut().Build();
+
+            // Act
+            var result = sut.Process(Model, CreateContext(copyMethods: false));
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Ok);
+            result.Value.Should().NotBeNull();
+            result.Value!.Methods.Should().BeEmpty();
         }
 
         [Fact]

--- a/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Interface/PipelineBuilderTests.cs
@@ -4,7 +4,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
 {
     public class Process : PipelineBuilderTests
     {
-        private InterfaceContext CreateContext(bool addProperties = true, bool copyMethods = true, Predicate<Method>? copyMethodPredicate = null) => new InterfaceContext
+        private InterfaceContext CreateContext(bool addProperties = true, bool copyMethods = true, Func<IType, Method, bool>? copyMethodPredicate = null) => new InterfaceContext
         (
             CreateInterfaceModel(addProperties),
             CreateSettingsForInterface
@@ -73,7 +73,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
             var sut = CreateSut().Build();
 
             // Act
-            var result = sut.Process(Model, CreateContext(copyMethodPredicate: _ => true));
+            var result = sut.Process(Model, CreateContext(copyMethodPredicate: (_, _) => true));
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -88,7 +88,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<Interfa
             var sut = CreateSut().Build();
 
             // Act
-            var result = sut.Process(Model, CreateContext(copyMethodPredicate: _ => false));
+            var result = sut.Process(Model, CreateContext(copyMethodPredicate: (_, _) => false));
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -315,6 +315,7 @@ public abstract class TestBase : IDisposable
         bool addSetters = false,
         bool copyAttributes = false,
         bool copyInterfaces = false,
+        bool copyMethods = false,
         bool allowGenerationWithoutProperties = false,
         bool enableEntityInheritance = false,
         bool isAbstract = false,
@@ -325,7 +326,8 @@ public abstract class TestBase : IDisposable
         IEnumerable<NamespaceMappingBuilder>? namespaceMappings = null,
         IEnumerable<TypenameMappingBuilder>? typenameMappings = null,
         Predicate<Domain.Attribute>? copyAttributePredicate = null,
-        Predicate<string>? copyInterfacePredicate = null)
+        Predicate<string>? copyInterfacePredicate = null,
+        Predicate<Method>? copyMethodPredicate = null)
         => new PipelineSettingsBuilder()
             .WithAddSetters(addSetters)
             .WithAllowGenerationWithoutProperties(allowGenerationWithoutProperties)
@@ -339,8 +341,10 @@ public abstract class TestBase : IDisposable
             .AddTypenameMappings(typenameMappings.DefaultWhenNull())
             .WithCopyAttributes(copyAttributes)
             .WithCopyInterfaces(copyInterfaces)
+            .WithCopyMethods(copyMethods)
             .WithCopyAttributePredicate(copyAttributePredicate)
-            .WithCopyInterfacePredicate(copyInterfacePredicate);
+            .WithCopyInterfacePredicate(copyInterfacePredicate)
+            .WithCopyMethodPredicate(copyMethodPredicate);
 
     protected static IEnumerable<NamespaceMappingBuilder> CreateNamespaceMappings(string sourceNamespace = "MySourceNamespace")
         =>

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -142,6 +142,7 @@ public abstract class TestBase : IDisposable
         bool copyInterfaces = false,
         bool addCopyConstructor = false,
         bool setDefaultValues = true,
+        bool inheritFromInterfaces = false,
         string newCollectionTypeName = "System.Collections.Generic.List",
         IEnumerable<NamespaceMappingBuilder>? namespaceMappings = null,
         IEnumerable<TypenameMappingBuilder>? typenameMappings = null,
@@ -170,7 +171,8 @@ public abstract class TestBase : IDisposable
                 copyAttributes: copyAttributes,
                 copyInterfaces: copyInterfaces,
                 copyAttributePredicate: copyAttributePredicate,
-                copyInterfacePredicate: copyInterfacePredicate
+                copyInterfacePredicate: copyInterfacePredicate,
+                inheritFromInterfaces: inheritFromInterfaces
             )
             .WithBuilderNewCollectionTypeName(newCollectionTypeName)
             .WithEnableNullableReferenceTypes(enableNullableReferenceTypes)
@@ -214,6 +216,7 @@ public abstract class TestBase : IDisposable
         bool createRecord = false,
         bool addBackingFields = false,
         bool createAsObservable = false,
+        bool inheritFromInterfaces = false,
         SubVisibility setterVisibility = SubVisibility.InheritFromParent,
         IEnumerable<NamespaceMappingBuilder>? namespaceMappings = null,
         IEnumerable<TypenameMappingBuilder>? typenameMappings = null,
@@ -226,6 +229,7 @@ public abstract class TestBase : IDisposable
             .WithCreateRecord(createRecord)
             .WithAddBackingFields(addBackingFields)
             .WithCreateAsObservable(createAsObservable)
+            .WithInheritFromInterfaces(inheritFromInterfaces)
             .WithAddNullChecks(addNullChecks)
             .WithUseExceptionThrowIfNull(useExceptionThrowIfNull)
             .WithEnableInheritance(enableEntityInheritance)

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -379,7 +379,7 @@ public abstract class TestBase : IDisposable
                     new MetadataBuilder().WithValue("ExpressionFramework.Domain.Builders.Evaluatables").WithName(MetadataNames.CustomBuilderNamespace),
                     new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(MetadataNames.CustomBuilderName),
                     new MetadataBuilder().WithValue("new ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder(source.[Name])").WithName(MetadataNames.CustomBuilderConstructorInitializeExpression),
-                    new MetadataBuilder().WithValue(new Literal("default(ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder)!", null)).WithName(MetadataNames.CustomBuilderDefaultValue),
+                    new MetadataBuilder().WithValue(new Literal("new ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder()", null)).WithName(MetadataNames.CustomBuilderDefaultValue),
                     new MetadataBuilder().WithValue("[Name][NullableSuffix].BuildTyped()").WithName(MetadataNames.CustomBuilderMethodParameterExpression)
                 ),
             new TypenameMappingBuilder()

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -77,6 +77,7 @@ public abstract class TestBase : IDisposable
                     new PropertyBuilder().WithName("Property2").WithTypeName(typeof(List<>).ReplaceGenericTypeName(typeof(string))).WithHasSetter(true)
                 }.Where(_ => addProperties)
             )
+            .AddMethods(new MethodBuilder().WithName("MyMethod"))
             .BuildTyped();
 
     protected static IConcreteType CreateGenericModel(bool addProperties)

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -327,7 +327,7 @@ public abstract class TestBase : IDisposable
         IEnumerable<TypenameMappingBuilder>? typenameMappings = null,
         Predicate<Domain.Attribute>? copyAttributePredicate = null,
         Predicate<string>? copyInterfacePredicate = null,
-        Predicate<Method>? copyMethodPredicate = null)
+        Func<IType, Method, bool>? copyMethodPredicate = null)
         => new PipelineSettingsBuilder()
             .WithAddSetters(addSetters)
             .WithAllowGenerationWithoutProperties(allowGenerationWithoutProperties)

--- a/src/ClassFramework.Pipelines/Builder/BuilderContext.cs
+++ b/src/ClassFramework.Pipelines/Builder/BuilderContext.cs
@@ -49,7 +49,7 @@ public class BuilderContext : ContextBase<IType>
     {
         property = property.IsNotNull(nameof(property));
 
-        if (!Settings.CopyInterfaces)
+        if (!Settings.CopyInterfaces || !Settings.InheritFromInterfaces)
         {
             return true;
         }

--- a/src/ClassFramework.Pipelines/Builder/Features/AddBuildMethodFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddBuildMethodFeature.cs
@@ -26,7 +26,7 @@ public class AddBuildMethodFeature : IPipelineFeature<IConcreteTypeBuilder, Buil
     {
         context = context.IsNotNull(nameof(context));
 
-        var returnType = context.Context.Settings.CopyInterfaces
+        var returnType = context.Context.Settings.InheritFromInterfaces
             ? context.Context.SourceModel.Interfaces.FirstOrDefault(x => x.GetClassName() == $"I{context.Context.SourceModel.Name}") ?? context.Context.SourceModel.GetFullName()
             : context.Context.SourceModel.GetFullName();
 

--- a/src/ClassFramework.Pipelines/Builder/Features/AddBuildMethodFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddBuildMethodFeature.cs
@@ -26,6 +26,10 @@ public class AddBuildMethodFeature : IPipelineFeature<IConcreteTypeBuilder, Buil
     {
         context = context.IsNotNull(nameof(context));
 
+        var returnType = context.Context.Settings.CopyInterfaces
+            ? context.Context.SourceModel.Interfaces.FirstOrDefault(x => x.GetClassName() == $"I{context.Context.SourceModel.Name}") ?? context.Context.SourceModel.GetFullName()
+            : context.Context.SourceModel.GetFullName();
+
         if (context.Context.Settings.EnableBuilderInheritance && context.Context.Settings.IsAbstract)
         {
             if (context.Context.Settings.IsForAbstractBuilder)
@@ -33,14 +37,14 @@ public class AddBuildMethodFeature : IPipelineFeature<IConcreteTypeBuilder, Buil
                 context.Model.AddMethods(new MethodBuilder()
                     .WithName("Build")
                     .WithAbstract()
-                    .WithReturnTypeName(context.Context.SourceModel.GetFullName()));
+                    .WithReturnTypeName(returnType));
             }
             else
             {
                 context.Model.AddMethods(new MethodBuilder()
                     .WithName("Build")
                     .WithOverride()
-                    .WithReturnTypeName(context.Context.SourceModel.GetFullName())
+                    .WithReturnTypeName(returnType)
                     .AddStringCodeStatements("return BuildTyped();"));
 
                 context.Model.AddMethods(new MethodBuilder()
@@ -62,7 +66,7 @@ public class AddBuildMethodFeature : IPipelineFeature<IConcreteTypeBuilder, Buil
             .WithName(GetName(context))
             .WithAbstract(context.Context.IsBuilderForAbstractEntity)
             .WithOverride(context.Context.IsBuilderForOverrideEntity)
-            .WithReturnTypeName($"{GetBuilderBuildMethodReturnType(context.Context)}{context.Context.SourceModel.GetGenericTypeArgumentsString()}")
+            .WithReturnTypeName($"{GetBuilderBuildMethodReturnType(context.Context, context.Context.IsBuilderForAbstractEntity || context.Context.IsBuilderForOverrideEntity ? context.Context.SourceModel.GetFullName() : returnType)}{context.Context.SourceModel.GetGenericTypeArgumentsString()}")
             .AddStringCodeStatements(context.Context.CreatePragmaWarningDisableStatementsForBuildMethod())
             .AddStringCodeStatements
             (
@@ -93,8 +97,8 @@ public class AddBuildMethodFeature : IPipelineFeature<IConcreteTypeBuilder, Buil
             ? context.Context.Settings.BuildTypedMethodName
             : context.Context.Settings.BuildMethodName;
 
-    private static string GetBuilderBuildMethodReturnType(BuilderContext context)
+    private static string GetBuilderBuildMethodReturnType(BuilderContext context, string returnType)
         => context.IsBuilderForAbstractEntity
             ? "TEntity"
-            : context.SourceModel.GetFullName();
+            : returnType;
 }

--- a/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime;
-
-namespace ClassFramework.Pipelines.Builder.Features;
+﻿namespace ClassFramework.Pipelines.Builder.Features;
 
 public class AddCopyConstructorFeatureBuilder : IBuilderFeatureBuilder
 {
@@ -203,14 +201,22 @@ public class AddCopyConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
         => instance.GetCustomValueForInheritedClass(settings.EnableInheritance, _ => Result.Success("base(source)")).Value!; //note that the delegate always returns success, so we can simply use the Value here
 
     private static ConstructorBuilder CreateInheritanceCopyConstructor(PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
-        => new ConstructorBuilder()
+    {
+        var typeName = context.Context.SourceModel.GetFullName();
+
+        if (context.Context.Settings.InheritFromInterfaces)
+        {
+            typeName = context.Context.MapTypeName(typeName, MetadataNames.CustomEntityInterfaceTypeName);
+        }
+
+        return new ConstructorBuilder()
             .WithChainCall("base(source)")
             .WithProtected(context.Context.IsBuilderForAbstractEntity)
             .AddParameters
             (
                 new ParameterBuilder()
                     .WithName("source")
-                    .WithTypeName($"{context.Context.SourceModel.GetFullName()}{context.Context.SourceModel.GetGenericTypeArgumentsString()}")
+                    .WithTypeName($"{typeName}{context.Context.SourceModel.GetGenericTypeArgumentsString()}")
             )
             .AddParameters
             (
@@ -219,4 +225,5 @@ public class AddCopyConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
                     .GetValues<Parameter>(MetadataNames.CustomBuilderCopyConstructorParameter)
                     .Select(x => x.ToBuilder())
             );
+    }
 }

--- a/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
@@ -163,7 +163,7 @@ public class AddCopyConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
                     () => property.TypeName.FixTypeName().IsCollectionTypeName()
                         ? context.Context.Settings.CollectionInitializationStatementFormatString
                         : context.Context.Settings.NonCollectionInitializationStatementFormatString
-                ).Replace("[Name]", property.Name), property.TypeName.FixTypeName().IsCollectionTypeName()),
+                ).Replace(PlaceholderNames.NamePlaceholder, property.Name), property.TypeName.FixTypeName().IsCollectionTypeName()),
             context.Context.FormatProvider,
             new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings)
         );
@@ -180,21 +180,21 @@ public class AddCopyConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
 
     private static string? GetSourceExpression(string? value, Property sourceProperty, PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
     {
-        if (value is null || !value.Contains("[SourceExpression]"))
+        if (value is null || !value.Contains(PlaceholderNames.SourceExpressionPlaceholder))
         {
             return value;
         }
 
-        if (value == "[SourceExpression]")
+        if (value == PlaceholderNames.SourceExpressionPlaceholder)
         {
             return sourceProperty.Name;
         }
 
         var metadata = sourceProperty.Metadata.WithMappingMetadata(sourceProperty.TypeName.GetCollectionItemType().WhenNullOrEmpty(sourceProperty.TypeName), context.Context.Settings);
-        var sourceExpression = metadata.GetStringValue(MetadataNames.CustomBuilderSourceExpression, "[Name]");
+        var sourceExpression = metadata.GetStringValue(MetadataNames.CustomBuilderSourceExpression, PlaceholderNames.NamePlaceholder);
         return sourceProperty.TypeName.FixTypeName().IsCollectionTypeName()
-            ? value.Replace("[SourceExpression]", $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace("[Name]", "x").Replace("[NullableSuffix]", string.Empty).Replace(".Select(x => x)", string.Empty)
-            : value.Replace("[SourceExpression]", sourceExpression).Replace("[Name]", sourceProperty.Name).Replace("[NullableSuffix]", sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes));
+            ? value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace(".Select(x => x)", string.Empty)
+            : value.Replace(PlaceholderNames.SourceExpressionPlaceholder, sourceExpression).Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name).Replace("[NullableSuffix]", sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes));
     }
 
     private static string CreateBuilderClassCopyConstructorChainCall(IType instance, PipelineSettings settings)

--- a/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddCopyConstructorFeature.cs
@@ -139,7 +139,7 @@ public class AddCopyConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
             .Select(x => new Tuple<string, Result<string>>
             (
                 x.GetBuilderMemberName(context.Context.Settings.AddNullChecks, context.Context.Settings.EnableNullableReferenceTypes, context.Context.Settings.OriginalValidateArguments, context.Context.Settings.AddBackingFields, context.Context.FormatProvider.ToCultureInfo()),
-                x.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, x, context.Context.Settings), context.Context.MapTypeName(x.TypeName), context.Context.Settings.BuilderNewCollectionTypeName, metadataName, _formattableStringParser)
+                x.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, x, context.Context.Settings), context.Context.MapTypeName(x.TypeName, MetadataNames.CustomEntityInterfaceTypeName), context.Context.Settings.BuilderNewCollectionTypeName, metadataName, _formattableStringParser)
             ))
             .TakeWhileWithFirstNonMatching(x => x.Item2.IsSuccessful())
             .ToArray();

--- a/src/ClassFramework.Pipelines/Builder/Features/AddDefaultConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddDefaultConstructorFeature.cs
@@ -56,7 +56,7 @@ public class AddDefaultConstructorFeature : IPipelineFeature<IConcreteTypeBuilde
             .Select(x => new
             {
                 Name = x.GetBuilderMemberName(context.Context.Settings.AddNullChecks, context.Context.Settings.EnableNullableReferenceTypes, context.Context.Settings.OriginalValidateArguments, context.Context.Settings.AddBackingFields, context.Context.FormatProvider.ToCultureInfo()),
-                Result = x.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, x, context.Context.Settings), context.Context.MapTypeName(x.TypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser)
+                Result = x.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, x, context.Context.Settings), context.Context.MapTypeName(x.TypeName, MetadataNames.CustomEntityInterfaceTypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser)
             })
             .TakeWhileWithFirstNonMatching(x => x.Result.IsSuccessful())
             .ToArray();

--- a/src/ClassFramework.Pipelines/Builder/Features/AddFluentMethodsForCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddFluentMethodsForCollectionPropertiesFeature.cs
@@ -36,7 +36,7 @@ public class AddFluentMethodsForCollectionPropertiesFeature : IPipelineFeature<I
             var parentChildContext = CreateParentChildContext(context, property);
 
             var resultSetBuilder = new NamedResultSetBuilder<string>();
-            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, parentChildContext, context.Context.MapTypeName(property.TypeName), _formattableStringParser));
+            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, parentChildContext, context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), _formattableStringParser));
             resultSetBuilder.Add("Namespace", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNamespaceFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("BuilderName", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNameFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("AddMethodName", () => _formattableStringParser.Parse(context.Context.Settings.AddMethodNameFormatString, context.Context.FormatProvider, parentChildContext));
@@ -125,7 +125,7 @@ public class AddFluentMethodsForCollectionPropertiesFeature : IPipelineFeature<I
             
             if (context.Context.Settings.OriginalValidateArguments == ArgumentValidationType.Shared)
             {
-                var constructorInitializerResult = property.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser); // note that we're not checking the status of this result, because it is using the same expression that we heve already checked before (typeNameResult, see above in this class)
+                var constructorInitializerResult = property.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser); // note that we're not checking the status of this result, because it is using the same expression that we heve already checked before (typeNameResult, see above in this class)
                 if (!constructorInitializerResult.IsSuccessful())
                 {
                     yield return constructorInitializerResult;

--- a/src/ClassFramework.Pipelines/Builder/Features/AddFluentMethodsForNonCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddFluentMethodsForNonCollectionPropertiesFeature.cs
@@ -36,7 +36,7 @@ public class AddFluentMethodsForNonCollectionPropertiesFeature : IPipelineFeatur
             var parentChildContext = new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings);
 
             var resultSetBuilder = new NamedResultSetBuilder<string>();
-            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName), _formattableStringParser));
+            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), _formattableStringParser));
             resultSetBuilder.Add("Namespace", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNamespaceFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("MethodName", () => _formattableStringParser.Parse(context.Context.Settings.SetMethodNameFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("BuilderName", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNameFormatString, context.Context.FormatProvider, parentChildContext));

--- a/src/ClassFramework.Pipelines/Builder/Features/AddPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/Builder/Features/AddPropertiesFeature.cs
@@ -33,7 +33,7 @@ public class AddPropertiesFeature : IPipelineFeature<IConcreteTypeBuilder, Build
 
         foreach (var property in context.Context.SourceModel.Properties.Where(x => context.Context.SourceModel.IsMemberValidForBuilderClass(x, context.Context.Settings)))
         {
-            var typeNameResult = property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName), _formattableStringParser);
+            var typeNameResult = property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), _formattableStringParser);
 
             if (!typeNameResult.IsSuccessful())
             {

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/Abstractions/IBuilderExtensionFeatureBuilder.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/Abstractions/IBuilderExtensionFeatureBuilder.cs
@@ -1,0 +1,5 @@
+﻿namespace ClassFramework.Pipelines.BuilderExtension.Features.Abstractions;
+
+public interface IBuilderExtensionFeatureBuilder : IBuilder<IPipelineFeature<IConcreteTypeBuilder, BuilderExtensionContext>>
+{
+}

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/Abstractions/IBuilderFeatureBuilder.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/Abstractions/IBuilderFeatureBuilder.cs
@@ -1,5 +1,0 @@
-﻿namespace ClassFramework.Pipelines.BuilderExtension.Features.Abstractions;
-
-public interface IBuilderInterfaceFeatureBuilder : IBuilder<IPipelineFeature<IConcreteTypeBuilder, BuilderExtensionContext>>
-{
-}

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForCollectionPropertiesFeature.cs
@@ -36,7 +36,7 @@ public class AddExtensionMethodsForCollectionPropertiesFeature : IPipelineFeatur
             var parentChildContext = CreateParentChildContext(context, property);
 
             var resultSetBuilder = new NamedResultSetBuilder<string>();
-            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName), _formattableStringParser));
+            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), _formattableStringParser));
             resultSetBuilder.Add("Namespace", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNamespaceFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("BuilderName", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNameFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("AddMethodName", () => _formattableStringParser.Parse(context.Context.Settings.AddMethodNameFormatString, context.Context.FormatProvider, parentChildContext));
@@ -120,7 +120,7 @@ public class AddExtensionMethodsForCollectionPropertiesFeature : IPipelineFeatur
 
             if (context.Context.Settings.OriginalValidateArguments == ArgumentValidationType.Shared)
             {
-                var constructorInitializerResult = property.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser); // note that we're not checking the status of this result, because it is using the same expression that we heve already checked before (typeNameResult, see above in this class)
+                var constructorInitializerResult = property.GetBuilderConstructorInitializer(context.Context.Settings, context.Context.FormatProvider, CreateParentChildContext(context, property), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), context.Context.Settings.BuilderNewCollectionTypeName, string.Empty, _formattableStringParser); // note that we're not checking the status of this result, because it is using the same expression that we heve already checked before (typeNameResult, see above in this class)
                 if (!constructorInitializerResult.IsSuccessful())
                 {
                     yield return constructorInitializerResult;

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForCollectionPropertiesFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class AddExtensionMethodsForCollectionPropertiesFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class AddExtensionMethodsForCollectionPropertiesFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     private readonly IFormattableStringParser _formattableStringParser;
 

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForNonCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForNonCollectionPropertiesFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class AddExtensionMethodsForNonCollectionPropertiesFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class AddExtensionMethodsForNonCollectionPropertiesFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     private readonly IFormattableStringParser _formattableStringParser;
 

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForNonCollectionPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/AddExtensionMethodsForNonCollectionPropertiesFeature.cs
@@ -36,7 +36,7 @@ public class AddExtensionMethodsForNonCollectionPropertiesFeature : IPipelineFea
             var parentChildContext = new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderExtensionContext>, Property>(context, property, context.Context.Settings);
 
             var resultSetBuilder = new NamedResultSetBuilder<string>();
-            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderExtensionContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName), _formattableStringParser));
+            resultSetBuilder.Add("TypeName", () => property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderExtensionContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), _formattableStringParser));
             resultSetBuilder.Add("Namespace", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNamespaceFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("MethodName", () => _formattableStringParser.Parse(context.Context.Settings.SetMethodNameFormatString, context.Context.FormatProvider, parentChildContext));
             resultSetBuilder.Add("BuilderName", () => _formattableStringParser.Parse(context.Context.Settings.BuilderNameFormatString, context.Context.FormatProvider, parentChildContext));

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/AddMetadataFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/AddMetadataFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class AddMetadataFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class AddMetadataFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     public IPipelineFeature<IConcreteTypeBuilder, BuilderExtensionContext> Build()
         => new AddMetadataFeature();

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/SetNameFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/SetNameFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class SetNameFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class SetNameFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     private readonly IFormattableStringParser _formattableStringParser;
 

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/SetNameFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/SetNameFeature.cs
@@ -28,7 +28,7 @@ public class SetNameFeature : IPipelineFeature<IConcreteTypeBuilder, BuilderExte
 
         var resultSetBuilder = new NamedResultSetBuilder<string>();
         resultSetBuilder.Add("Name", () => _formattableStringParser.Parse(context.Context.Settings.BuilderExtensionsNameFormatString, context.Context.FormatProvider, context));
-        resultSetBuilder.Add("Namespace", () => context.Context.SourceModel.Metadata.WithMappingMetadata(context.Context.SourceModel.GetFullName().GetCollectionItemType().WhenNullOrEmpty(context.Context.SourceModel.GetFullName), context.Context.Settings).GetStringResult(MetadataNames.CustomBuilderNamespace, () => _formattableStringParser.Parse(context.Context.Settings.BuilderExtensionsNamespaceFormatString, context.Context.FormatProvider, context)));
+        resultSetBuilder.Add("Namespace", () => _formattableStringParser.Parse(context.Context.Settings.BuilderExtensionsNamespaceFormatString, context.Context.FormatProvider, context));
         var results = resultSetBuilder.Build();
 
         var error = Array.Find(results, x => !x.Result.IsSuccessful());

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/SetStaticFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/SetStaticFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class SetStaticFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class SetStaticFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     public IPipelineFeature<IConcreteTypeBuilder, BuilderExtensionContext> Build()
         => new SetStaticFeature();

--- a/src/ClassFramework.Pipelines/BuilderExtension/Features/ValidationFeature.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/Features/ValidationFeature.cs
@@ -1,6 +1,6 @@
 ﻿namespace ClassFramework.Pipelines.BuilderExtension.Features;
 
-public class ValidationFeatureBuilder : IBuilderInterfaceFeatureBuilder
+public class ValidationFeatureBuilder : IBuilderExtensionFeatureBuilder
 {
     public IPipelineFeature<IConcreteTypeBuilder, BuilderExtensionContext> Build() => new ValidationFeature();
 }

--- a/src/ClassFramework.Pipelines/BuilderExtension/PipelineBuilder.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/PipelineBuilder.cs
@@ -4,7 +4,7 @@ public class PipelineBuilder : PipelineBuilder<IConcreteTypeBuilder, BuilderExte
 {
     public PipelineBuilder(
         IEnumerable<ISharedFeatureBuilder> sharedFeatureBuilders,
-        IEnumerable<IBuilderInterfaceFeatureBuilder> builderInterfaceFeatureBuilders)
+        IEnumerable<IBuilderExtensionFeatureBuilder> builderInterfaceFeatureBuilders)
     {
         AddFeatures(builderInterfaceFeatureBuilders);
         AddFeatures(sharedFeatureBuilders.Select(x => x.BuildFor<BuilderExtensionContext>()));

--- a/src/ClassFramework.Pipelines/ContextBase.cs
+++ b/src/ClassFramework.Pipelines/ContextBase.cs
@@ -28,20 +28,7 @@ public abstract class ContextBase<TModel>
     public string MapTypeName(string typeName, string alternateTypeMetadataName = "")
     {
         typeName = typeName.IsNotNull(nameof(typeName));
-        var result = typeName.MapTypeName(Settings, NewCollectionTypeName);
-
-        if (Settings.InheritFromInterfaces && !string.IsNullOrEmpty(alternateTypeMetadataName))
-        {
-            var typenameMapping = Settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == (typeName.IsCollectionTypeName() ? typeName.GetGenericArguments() : typeName));
-            if (typenameMapping is not null)
-            {
-                var alternateType = typenameMapping.Metadata.GetStringValue(alternateTypeMetadataName);
-                if (!string.IsNullOrEmpty(alternateType))
-                {
-                    return alternateType;
-                }
-            }
-        }
+        var result = typeName.MapTypeName(Settings, NewCollectionTypeName, alternateTypeMetadataName);
 
         return result;
     }

--- a/src/ClassFramework.Pipelines/ContextBase.cs
+++ b/src/ClassFramework.Pipelines/ContextBase.cs
@@ -30,7 +30,7 @@ public abstract class ContextBase<TModel>
         typeName = typeName.IsNotNull(nameof(typeName));
         var result = typeName.MapTypeName(Settings, NewCollectionTypeName);
 
-        if (Settings.CopyInterfaces && !string.IsNullOrEmpty(alternateTypeMetadataName))
+        if (Settings.InheritFromInterfaces && !string.IsNullOrEmpty(alternateTypeMetadataName))
         {
             var typenameMapping = Settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == (typeName.IsCollectionTypeName() ? typeName.GetGenericArguments() : typeName));
             if (typenameMapping is not null)

--- a/src/ClassFramework.Pipelines/ContextBase.cs
+++ b/src/ClassFramework.Pipelines/ContextBase.cs
@@ -25,8 +25,26 @@ public abstract class ContextBase<TModel>
         return $"if ({argumentName} is null) throw new {typeof(ArgumentNullException).FullName}(nameof({argumentName}));";
     }
 
-    public string MapTypeName(string typeName)
-        => typeName.IsNotNull(nameof(typeName)).MapTypeName(Settings, NewCollectionTypeName);
+    public string MapTypeName(string typeName, string alternateTypeMetadataName = "")
+    {
+        typeName = typeName.IsNotNull(nameof(typeName));
+        var result = typeName.MapTypeName(Settings, NewCollectionTypeName);
+
+        if (Settings.CopyInterfaces && !string.IsNullOrEmpty(alternateTypeMetadataName))
+        {
+            var typenameMapping = Settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == (typeName.IsCollectionTypeName() ? typeName.GetGenericArguments() : typeName));
+            if (typenameMapping is not null)
+            {
+                var alternateType = typenameMapping.Metadata.GetStringValue(alternateTypeMetadataName);
+                if (!string.IsNullOrEmpty(alternateType))
+                {
+                    return alternateType;
+                }
+            }
+        }
+
+        return result;
+    }
 
     public string MapNamespace(string? ns)
         => ns.MapNamespace(Settings);

--- a/src/ClassFramework.Pipelines/Entity/Features/AddFullConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddFullConstructorFeature.cs
@@ -61,7 +61,7 @@ public class AddFullConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, 
 
         return Result.Success(new ConstructorBuilder()
             .WithProtected(context.Context.Settings.EnableInheritance && context.Context.Settings.IsAbstract)
-            .AddParameters(context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, context.Context.MapTypeName))
+            .AddParameters(context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, n => context.Context.MapTypeName(n, MetadataNames.CustomEntityInterfaceTypeName)))
             .AddStringCodeStatements
             (
                 context.Context.SourceModel.Properties

--- a/src/ClassFramework.Pipelines/Entity/Features/AddPropertiesFeature.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddPropertiesFeature.cs
@@ -53,7 +53,7 @@ public class AddPropertiesFeature : IPipelineFeature<IConcreteTypeBuilder, Entit
                 (
                     property =>new FieldBuilder()
                         .WithName($"_{property.Name.ToPascalCase(context.Context.FormatProvider.ToCultureInfo())}")
-                        .WithTypeName(context.Context.MapTypeName(property.TypeName)
+                        .WithTypeName(context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName)
                             .FixCollectionTypeName(context.Context.Settings.CollectionTypeName
                                 .WhenNullOrEmpty(context.Context.Settings.EntityNewCollectionTypeName)
                                 .WhenNullOrEmpty(typeof(List<>).WithoutGenerics()))

--- a/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
@@ -103,6 +103,10 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
     {
         if (context.Context.Settings.InheritFromInterfaces)
         {
+            if (context.Context.SourceModel.Interfaces.Count > 0)
+            {
+                return $"{builderInterfaceNamespaceResult.Value}.{context.Context.SourceModel.Interfaces.First().GetClassName()}Builder";
+            }
             return $"{builderInterfaceNamespaceResult.Value}.I{builderConcreteName}Builder";
         }
         else if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)

--- a/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
@@ -52,13 +52,6 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
         var name = results.First(x => x.Name == "Name").Result.Value!;
 
         var entityFullName = $"{ns.AppendWhenNotNullOrEmpty(".")}{name}";
-        /*if (context.Context.Settings.InheritFromInterfaces)
-        {
-            entityFullName = context.Context.MapTypeName(entityFullName, MetadataNames.CustomEntityInterfaceTypeName);
-            //ns = entityFullName.GetNamespaceWithDefault();
-            //name = entityFullName.GetClassName();
-        }*/
-
         if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)
         {
             entityFullName = entityFullName.ReplaceSuffix("Base", string.Empty, StringComparison.Ordinal);
@@ -69,6 +62,7 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
             : entityFullName;
 
         var builderNamespaceResult = context.Context.SourceModel.Metadata.WithMappingMetadata(entityFullName.GetCollectionItemType().WhenNullOrEmpty(entityFullName), context.Context.Settings).GetStringResult(MetadataNames.CustomBuilderNamespace, () => Result.Success($"{ns.AppendWhenNotNullOrEmpty(".")}Builders"));
+        var builderInterfaceNamespaceResult = context.Context.SourceModel.Metadata.WithMappingMetadata(entityFullName.GetCollectionItemType().WhenNullOrEmpty(entityFullName), context.Context.Settings).GetStringResult(MetadataNames.CustomBuilderInterfaceNamespace, () => Result.Success($"{ns.AppendWhenNotNullOrEmpty(".")}Builders"));
         var concreteBuilderNamespaceResult = context.Context.SourceModel.Metadata.WithMappingMetadata(entityConcreteFullName.GetCollectionItemType().WhenNullOrEmpty(entityConcreteFullName), context.Context.Settings).GetStringResult(MetadataNames.CustomBuilderNamespace, () => Result.Success($"{ns.AppendWhenNotNullOrEmpty(".")}Builders"));
 
         var builderConcreteName = context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is null
@@ -77,9 +71,7 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
 
         var builderConcreteTypeName = $"{builderNamespaceResult.Value}.{builderConcreteName}Builder";
 
-        var builderTypeName = context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null
-            ? $"{concreteBuilderNamespaceResult.Value}.{context.Context.Settings.BaseClass.Name}Builder"
-            : builderConcreteTypeName;
+        var builderTypeName = GetBuilderTypeName(context, builderInterfaceNamespaceResult, concreteBuilderNamespaceResult, builderConcreteName, builderConcreteTypeName);
 
         var returnStatement = context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null && !string.IsNullOrEmpty(typedMethodName)
             ? $"return {typedMethodName}();"
@@ -105,6 +97,22 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
         }
 
         return Result.Continue<IConcreteTypeBuilder>();
+    }
+
+    private static string GetBuilderTypeName(PipelineContext<IConcreteTypeBuilder, EntityContext> context, Result<string> builderInterfaceNamespaceResult, Result<string> concreteBuilderNamespaceResult, string builderConcreteName, string builderConcreteTypeName)
+    {
+        if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)
+        {
+            return $"{concreteBuilderNamespaceResult.Value}.{context.Context.Settings.BaseClass.Name}Builder";
+        }
+        else if (context.Context.Settings.InheritFromInterfaces)
+        {
+            return $"{builderInterfaceNamespaceResult.Value}.I{builderConcreteName}Builder";
+        }
+        else
+        {
+            return builderConcreteTypeName;
+        }
     }
 
     public IBuilder<IPipelineFeature<IConcreteTypeBuilder, EntityContext>> ToBuilder()

--- a/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
@@ -101,15 +101,15 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
 
     private static string GetBuilderTypeName(PipelineContext<IConcreteTypeBuilder, EntityContext> context, Result<string> builderInterfaceNamespaceResult, Result<string> concreteBuilderNamespaceResult, string builderConcreteName, string builderConcreteTypeName)
     {
-        if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)
-        {
-            return $"{concreteBuilderNamespaceResult.Value}.{context.Context.Settings.BaseClass.Name}Builder";
-        }
-        else if (context.Context.Settings.InheritFromInterfaces)
+        if (context.Context.Settings.InheritFromInterfaces)
         {
             return $"{builderInterfaceNamespaceResult.Value}.I{builderConcreteName}Builder";
         }
-        else
+        else if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)
+        {
+            return $"{concreteBuilderNamespaceResult.Value}.{context.Context.Settings.BaseClass.Name}Builder";
+        }
+        else 
         {
             return builderConcreteTypeName;
         }

--- a/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
@@ -103,9 +103,9 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
     {
         if (context.Context.Settings.InheritFromInterfaces)
         {
-            if (context.Context.SourceModel.Interfaces.Count > 0)
+            if (context.Context.SourceModel.Interfaces.Count >= 2)
             {
-                return $"{builderInterfaceNamespaceResult.Value}.{context.Context.SourceModel.Interfaces.First().GetClassName()}Builder";
+                return $"{builderInterfaceNamespaceResult.Value}.{context.Context.SourceModel.Interfaces.ElementAt(1).GetClassName()}Builder";
             }
             return $"{builderInterfaceNamespaceResult.Value}.I{builderConcreteName}Builder";
         }

--- a/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
+++ b/src/ClassFramework.Pipelines/Entity/Features/AddToBuilderMethod.cs
@@ -52,6 +52,13 @@ public class AddToBuilderMethodFeature : IPipelineFeature<IConcreteTypeBuilder, 
         var name = results.First(x => x.Name == "Name").Result.Value!;
 
         var entityFullName = $"{ns.AppendWhenNotNullOrEmpty(".")}{name}";
+        /*if (context.Context.Settings.InheritFromInterfaces)
+        {
+            entityFullName = context.Context.MapTypeName(entityFullName, MetadataNames.CustomEntityInterfaceTypeName);
+            //ns = entityFullName.GetNamespaceWithDefault();
+            //name = entityFullName.GetClassName();
+        }*/
+
         if (context.Context.Settings.EnableInheritance && context.Context.Settings.BaseClass is not null)
         {
             entityFullName = entityFullName.ReplaceSuffix("Base", string.Empty, StringComparison.Ordinal);

--- a/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
@@ -76,7 +76,7 @@ public static class PipelineContextExtensions
                         (
                             property.TypeName.GetCollectionItemType().WhenNullOrEmpty(property.TypeName),
                             context.Context.Settings
-                        ).GetStringValue(MetadataNames.CustomBuilderMethodParameterExpression, "[Name]"),
+                        ).GetStringValue(MetadataNames.CustomBuilderMethodParameterExpression, PlaceholderNames.NamePlaceholder),
                     context.Context.FormatProvider,
                     new ParentChildContext<PipelineContext<TModel, BuilderContext>, Property>(context, property, context.Context.Settings)
                 ),
@@ -103,12 +103,12 @@ public static class PipelineContextExtensions
 
     private static string? GetBuilderPropertyExpression(this string? value, Property sourceProperty, string collectionInitializer, string suffix)
     {
-        if (value is null || !value.Contains("[Name]"))
+        if (value is null || !value.Contains(PlaceholderNames.NamePlaceholder))
         {
             return value;
         }
 
-        if (value == "[Name]")
+        if (value == PlaceholderNames.NamePlaceholder)
         {
             return sourceProperty.Name;
         }
@@ -119,7 +119,7 @@ public static class PipelineContextExtensions
         }
         else
         {
-            return value!.Replace("[Name]", sourceProperty.Name).Replace("[NullableSuffix]", suffix);
+            return value!.Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name).Replace("[NullableSuffix]", suffix);
         }
     }
 
@@ -127,7 +127,7 @@ public static class PipelineContextExtensions
         => collectionInitializer
             .Replace("[Type]", sourceProperty.TypeName.FixTypeName().WithoutProcessedGenerics())
             .Replace("[Generics]", sourceProperty.TypeName.FixTypeName().GetGenericArguments())
-            .Replace("[Expression]", $"{sourceProperty.Name}{suffix}.Select(x => {value!.Replace("[Name]", "x").Replace("[NullableSuffix]", string.Empty)})");
+            .Replace("[Expression]", $"{sourceProperty.Name}{suffix}.Select(x => {value!.Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty)})");
 
     private static string GetBuilderPocoCloseSign(bool poco)
         => poco

--- a/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
@@ -57,7 +57,7 @@ public static class PipelineContextExtensions
         => string.Join(", ", properties.Select(x => x.Name.ToPascalCase(cultureInfo).GetCsharpFriendlyName()));
 
     private static string CreateImmutableClassCtorParameterNames<TModel>(PipelineContext<TModel, EntityContext> context)
-        => string.Join(", ", context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, context.Context.MapTypeName).Select(x => x.Name.GetCsharpFriendlyName()));
+        => string.Join(", ", context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, n => context.Context.MapTypeName(n)).Select(x => x.Name.GetCsharpFriendlyName()));
 
     private static Result<string> GetConstructionMethodParameters<TModel>(PipelineContext<TModel, BuilderContext> context, IFormattableStringParser formattableStringParser, bool hasPublicParameterlessConstructor)
     {

--- a/src/ClassFramework.Pipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/ServiceCollectionExtensions.cs
@@ -45,12 +45,12 @@ public static class ServiceCollectionExtensions
         => services
             .AddScoped(services => services.GetRequiredService<IPipelineBuilder<IConcreteTypeBuilder, BuilderExtensionContext>>().Build())
             .AddScoped<IPipelineBuilder<IConcreteTypeBuilder, BuilderExtensionContext>, BuilderExtension.PipelineBuilder>()
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.ValidationFeatureBuilder>() // important to register this one first, because validation should be performed first
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.AddExtensionMethodsForCollectionPropertiesFeatureBuilder>()
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.AddExtensionMethodsForNonCollectionPropertiesFeatureBuilder>()
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.AddMetadataFeatureBuilder>()
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.SetNameFeatureBuilder>()
-            .AddScoped<IBuilderInterfaceFeatureBuilder, BuilderExtension.Features.SetStaticFeatureBuilder>();
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.ValidationFeatureBuilder>() // important to register this one first, because validation should be performed first
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.AddExtensionMethodsForCollectionPropertiesFeatureBuilder>()
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.AddExtensionMethodsForNonCollectionPropertiesFeatureBuilder>()
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.AddMetadataFeatureBuilder>()
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.SetNameFeatureBuilder>()
+            .AddScoped<IBuilderExtensionFeatureBuilder, BuilderExtension.Features.SetStaticFeatureBuilder>();
 
     private static IServiceCollection AddEntityPipeline(this IServiceCollection services)
         => services

--- a/src/ClassFramework.Pipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/ServiceCollectionExtensions.cs
@@ -109,6 +109,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IInterfaceFeatureBuilder, Interface.Features.AddAttributesFeatureBuilder>()
             .AddScoped<IInterfaceFeatureBuilder, Interface.Features.AddInterfacesFeatureBuilder>()
             .AddScoped<IInterfaceFeatureBuilder, Interface.Features.AddMetadataFeatureBuilder>()
+            .AddScoped<IInterfaceFeatureBuilder, Interface.Features.AddMethodsFeatureBuilder>()
             .AddScoped<IInterfaceFeatureBuilder, Interface.Features.AddPropertiesFeatureBuilder>()
             .AddScoped<IInterfaceFeatureBuilder, Interface.Features.SetNameFeatureBuilder>()
         ;

--- a/src/ClassFramework.Pipelines/Extensions/StringExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/StringExtensions.cs
@@ -13,37 +13,18 @@ public static class StringExtensions
             // i.e. IEnumerable<TSource> => IEnumerable<TTarget> (including collection typename mapping, when available)
             return typeName
                 .FixCollectionTypeName(newCollectionTypeName) // note that this always converts to a generic type :)
-                .ReplaceGenericTypeName(MapTypeName(typeName.GetCollectionItemType(), settings, newCollectionTypeName, alternateTypeMetadataName)); // so we can safely use ReplaceGenericTypeName here
+                .ReplaceGenericTypeName(typeName.GetCollectionItemType().MapTypeName(settings, newCollectionTypeName, alternateTypeMetadataName)); // so we can safely use ReplaceGenericTypeName here
         }
 
         if (settings.InheritFromInterfaces && !string.IsNullOrEmpty(alternateTypeMetadataName))
         {
-            var typenameMapping = settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == (typeName.IsCollectionTypeName() ? typeName.GetGenericArguments() : typeName));
-            if (typenameMapping is not null)
-            {
-                var alternateType = typenameMapping.Metadata.GetStringValue(alternateTypeMetadataName);
-                if (!string.IsNullOrEmpty(alternateType))
-                {
-                    return alternateType;
-                }
-            }
+            return MapTypeUsingAlternateTypeMetadata(typeName, settings, newCollectionTypeName, alternateTypeMetadataName);
         }
 
         var genericArguments = typeName.FixTypeName().GetProcessedGenericArguments();
         if (!string.IsNullOrEmpty(genericArguments))
         {
-            var mappedGenericArgumentsBuilder = new StringBuilder();
-            foreach (var item in genericArguments.Split(',').Select(x => x.Trim()))
-            {
-                if (mappedGenericArgumentsBuilder.Length > 0)
-                {
-                    mappedGenericArgumentsBuilder.Append(",");
-                }
-
-                mappedGenericArgumentsBuilder.Append(MapTypeName(item, settings, newCollectionTypeName, alternateTypeMetadataName));
-            }
-
-            return $"{MapTypeName(typeName.FixTypeName().WithoutProcessedGenerics(), settings, newCollectionTypeName, alternateTypeMetadataName)}<{mappedGenericArgumentsBuilder}>";
+            return MapTypeUsingGenerics(typeName, settings, newCollectionTypeName, alternateTypeMetadataName, genericArguments);
         }
 
         var typeNameMapping = settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == typeName);
@@ -65,6 +46,37 @@ public static class StringExtensions
         }
 
         return typeName;
+    }
+
+    private static string MapTypeUsingGenerics(string typeName, PipelineSettings settings, string newCollectionTypeName, string alternateTypeMetadataName, string genericArguments)
+    {
+        var mappedGenericArgumentsBuilder = new StringBuilder();
+        foreach (var item in genericArguments.Split(',').Select(x => x.Trim()))
+        {
+            if (mappedGenericArgumentsBuilder.Length > 0)
+            {
+                mappedGenericArgumentsBuilder.Append(",");
+            }
+
+            mappedGenericArgumentsBuilder.Append(item.MapTypeName(settings, newCollectionTypeName, alternateTypeMetadataName));
+        }
+
+        return $"{typeName.FixTypeName().WithoutProcessedGenerics().MapTypeName(settings, newCollectionTypeName, alternateTypeMetadataName)}<{mappedGenericArgumentsBuilder}>";
+    }
+
+    private static string MapTypeUsingAlternateTypeMetadata(string typeName, PipelineSettings settings, string newCollectionTypeName, string alternateTypeMetadataName)
+    {
+        var typenameMapping = settings.TypenameMappings.FirstOrDefault(x => x.SourceTypeName == (typeName.IsCollectionTypeName() ? typeName.GetGenericArguments() : typeName));
+        if (typenameMapping is not null)
+        {
+            var alternateType = typenameMapping.Metadata.GetStringValue(alternateTypeMetadataName);
+            if (!string.IsNullOrEmpty(alternateType))
+            {
+                return alternateType;
+            }
+        }
+
+        return typeName.MapTypeName(settings, newCollectionTypeName, string.Empty);
     }
 
     public static string MapNamespace(this string? ns, PipelineSettings settings)

--- a/src/ClassFramework.Pipelines/Extensions/TypeBaseExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/TypeBaseExtensions.cs
@@ -104,7 +104,7 @@ public static class TypeBaseExtensions
             instance.IsMemberValidForBuilderClass(x, context.Context.Settings)
             && x.HasBackingFieldOnBuilder(context.Context.Settings.AddNullChecks, context.Context.Settings.EnableNullableReferenceTypes, context.Context.Settings.OriginalValidateArguments, context.Context.Settings.AddBackingFields)))
         {
-            var builderArgumentTypeResult = property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName), formattableStringParser);
+            var builderArgumentTypeResult = property.GetBuilderArgumentTypeName(context.Context.Settings, context.Context.FormatProvider, new ParentChildContext<PipelineContext<IConcreteTypeBuilder, BuilderContext>, Property>(context, property, context.Context.Settings), context.Context.MapTypeName(property.TypeName, MetadataNames.CustomEntityInterfaceTypeName), formattableStringParser);
 
             if (!builderArgumentTypeResult.IsSuccessful())
             {

--- a/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
+++ b/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
@@ -20,8 +20,8 @@ public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceCon
         context.Model.AddMethods(context.Context.SourceModel.Methods
             .Where(x => context.Context.Settings.CopyMethodPredicate is null || context.Context.Settings.CopyMethodPredicate(context.Context.SourceModel, x))
             .Select(x => x.ToBuilder()
-                .WithReturnTypeName(context.Context.MapTypeName(x.ReturnTypeName.FixCollectionTypeName(context.Context.Settings.EntityNewCollectionTypeName).FixNullableTypeName(new TypeContainerWrapper(x))))
-                .With(y => y.Parameters.ForEach(z => z.TypeName = context.Context.MapTypeName(z.TypeName)))
+                .WithReturnTypeName(context.Context.MapTypeName(x.ReturnTypeName.FixCollectionTypeName(context.Context.Settings.EntityNewCollectionTypeName).FixNullableTypeName(new TypeContainerWrapper(x)), MetadataNames.CustomEntityInterfaceTypeName))
+                .With(y => y.Parameters.ForEach(z => z.TypeName = context.Context.MapTypeName(z.TypeName, MetadataNames.CustomEntityInterfaceTypeName)))
             ));
 
         return Result.Continue<InterfaceBuilder>();

--- a/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
+++ b/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
@@ -1,0 +1,22 @@
+﻿namespace ClassFramework.Pipelines.Interface.Features;
+
+public class AddMethodsFeatureBuilder : IInterfaceFeatureBuilder
+{
+    public IPipelineFeature<InterfaceBuilder, InterfaceContext> Build()
+        => new AddMethodsFeature();
+}
+
+public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceContext>
+{
+    public Result<InterfaceBuilder> Process(PipelineContext<InterfaceBuilder, InterfaceContext> context)
+    {
+        context = context.IsNotNull(nameof(context));
+
+        context.Model.AddMethods(context.Context.SourceModel.Methods.Select(x => x.ToBuilder()));
+
+        return Result.Continue<InterfaceBuilder>();
+    }
+
+    public IBuilder<IPipelineFeature<InterfaceBuilder, InterfaceContext>> ToBuilder()
+        => new AddMethodsFeatureBuilder();
+}

--- a/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
+++ b/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
@@ -31,6 +31,7 @@ public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceCon
         => new AddMethodsFeatureBuilder();
 }
 
+[ExcludeFromCodeCoverage]
 internal sealed class TypeContainerWrapper : ITypeContainer
 {
     public TypeContainerWrapper(Method method)

--- a/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
+++ b/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
@@ -18,7 +18,7 @@ public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceCon
         }
 
         context.Model.AddMethods(context.Context.SourceModel.Methods
-            .Where(x => context.Context.Settings.CopyMethodPredicate is null || context.Context.Settings.CopyMethodPredicate(x))
+            .Where(x => context.Context.Settings.CopyMethodPredicate is null || context.Context.Settings.CopyMethodPredicate(context.Context.SourceModel, x))
             .Select(x => x.ToBuilder()
                 .WithReturnTypeName(context.Context.MapTypeName(x.ReturnTypeName.FixCollectionTypeName(context.Context.Settings.EntityNewCollectionTypeName).FixNullableTypeName(new TypeContainerWrapper(x))))
                 .With(y => y.Parameters.ForEach(z => z.TypeName = context.Context.MapTypeName(z.TypeName)))
@@ -31,7 +31,7 @@ public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceCon
         => new AddMethodsFeatureBuilder();
 }
 
-internal class TypeContainerWrapper : ITypeContainer
+internal sealed class TypeContainerWrapper : ITypeContainer
 {
     public TypeContainerWrapper(Method method)
     {

--- a/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
+++ b/src/ClassFramework.Pipelines/Interface/Features/AddMethodsFeature.cs
@@ -12,7 +12,14 @@ public class AddMethodsFeature : IPipelineFeature<InterfaceBuilder, InterfaceCon
     {
         context = context.IsNotNull(nameof(context));
 
-        context.Model.AddMethods(context.Context.SourceModel.Methods.Select(x => x.ToBuilder()));
+        if (!context.Context.Settings.CopyMethods)
+        {
+            return Result.Continue<InterfaceBuilder>();
+        }
+
+        context.Model.AddMethods(context.Context.SourceModel.Methods
+            .Where(x => context.Context.Settings.CopyMethodPredicate is null || context.Context.Settings.CopyMethodPredicate(x))
+            .Select(x => x.ToBuilder()));
 
         return Result.Continue<InterfaceBuilder>();
     }

--- a/src/ClassFramework.Pipelines/MetadataNames.cs
+++ b/src/ClassFramework.Pipelines/MetadataNames.cs
@@ -116,4 +116,9 @@ public static class MetadataNames
     /// Metadata name for defining custom parameters for copy constructors. Value needs to be of type Parameter.
     /// </summary>
     public const string CustomBuilderCopyConstructorParameter = "ClassFramework.Builder.CopyConstructor.Parameter";
+
+    /// <summary>
+    /// Metadata name for defining custom interface typename on entities
+    /// </summary>
+    public const string CustomEntityInterfaceTypeName = "ClassFramework.Entity.Interface.TypeName";
 }

--- a/src/ClassFramework.Pipelines/OverrideEntity/Features/AddConstructorFeature.cs
+++ b/src/ClassFramework.Pipelines/OverrideEntity/Features/AddConstructorFeature.cs
@@ -47,7 +47,7 @@ public class AddConstructorFeature : IPipelineFeature<IConcreteTypeBuilder, Over
         return Result.Success(new ConstructorBuilder()
             .WithProtected(context.Context.Settings.EnableInheritance && context.Context.Settings.IsAbstract)
             .WithChainCall($"base({parameters})")
-            .AddParameters(context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, context.Context.MapTypeName))
+            .AddParameters(context.Context.SourceModel.Properties.CreateImmutableClassCtorParameters(context.Context.FormatProvider, context.Context.Settings, n => context.Context.MapTypeName(n, MetadataNames.CustomEntityInterfaceTypeName)))
             );
     }
 }

--- a/src/ClassFramework.Pipelines/PlaceholderNames.cs
+++ b/src/ClassFramework.Pipelines/PlaceholderNames.cs
@@ -1,0 +1,7 @@
+﻿namespace ClassFramework.Pipelines;
+
+internal static class PlaceholderNames
+{
+    internal const string NamePlaceholder = "[Name]";
+    internal const string SourceExpressionPlaceholder = "[SourceExpression]";
+}

--- a/src/ClassFramework.Pipelines/Reflection/Features/AddInterfacesFeature.cs
+++ b/src/ClassFramework.Pipelines/Reflection/Features/AddInterfacesFeature.cs
@@ -21,7 +21,7 @@ public class AddInterfacesFeature : IPipelineFeature<TypeBaseBuilder, Reflection
             context.Context.SourceModel.GetInterfaces()
                 .Select(x => x.FullName.FixTypeName())
                 .Where(x => context.Context.Settings.CopyInterfacePredicate?.Invoke(x) ?? true)
-                .Select(context.Context.MapTypeName)
+                .Select(n => context.Context.MapTypeName(n))
         );
 
         return Result.Continue<TypeBaseBuilder>();

--- a/src/ClassFramework.Pipelines/Usings.cs
+++ b/src/ClassFramework.Pipelines/Usings.cs
@@ -1,5 +1,6 @@
 ﻿global using System.ComponentModel;
 global using System.ComponentModel.DataAnnotations;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.Reflection;
 global using System.Text;

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
@@ -6,7 +6,7 @@ public class ImmutableCoreEntities : ImmutableCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetCoreModels(), "Test.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces : ImmutableInheritFromInterfacesCSharpClassBase
+{
+    public ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    public override IEnumerable<TypeBase> Model => GetBuilderInterfaces(GetCoreModels(), "Test.Domain.Builders", "Test.Domain", "Test.Abstractions");
+
+    public override string Path => "Test.Domain";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableInheritFromInterfacesAbstractionsInterfaces : ImmutableInheritFromInterfacesCSharpClassBase
+{
+    public ImmutableInheritFromInterfacesAbstractionsInterfaces(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    public override IEnumerable<TypeBase> Model => GetEntityInterfaces(GetCoreModels(), "Test.Domain", "Test.Abstractions");
+
+    public override string Path => "Test.Domain";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCSharpClassBase.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCSharpClassBase.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public abstract class ImmutableInheritFromInterfacesCSharpClassBase : ImmutableCSharpClassBase
+{
+    protected ImmutableInheritFromInterfacesCSharpClassBase(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    protected override bool InheritFromInterfaces => true;
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableInheritFromInterfacesCoreBuilders : ImmutableInheritFromInterfacesCSharpClassBase
+{
+    public ImmutableInheritFromInterfacesCoreBuilders(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    public override IEnumerable<TypeBase> Model => GetBuilders(GetCoreModels().Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain.Builders", "Test.Domain");
+
+    public override string Path => "Test.Domain/Builders";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableInheritFromInterfacesCoreEntities : ImmutableInheritFromInterfacesCSharpClassBase
+{
+    public ImmutableInheritFromInterfacesCoreEntities(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels().Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain");
+
+    public override string Path => "Test.Domain";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCSharpClassBase.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCSharpClassBase.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public abstract class ImmutableNoToBuilderMethodCSharpClassBase : ImmutableCSharpClassBase
+{
+    protected ImmutableNoToBuilderMethodCSharpClassBase(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    protected override SubVisibility SetterVisibility => SubVisibility.Private;
+    protected override string ToBuilderFormatString => string.Empty;
+    protected override string ToTypedBuilderFormatString => string.Empty;
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
@@ -1,0 +1,12 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableNoToBuilderMethodCoreEntities : ImmutableNoToBuilderMethodCSharpClassBase
+{
+    public ImmutableNoToBuilderMethodCoreEntities(ICsharpExpressionCreator csharpExpressionCreator, IPipeline<IConcreteTypeBuilder, BuilderContext> builderPipeline, IPipeline<IConcreteTypeBuilder, BuilderExtensionContext> builderExtensionPipeline, IPipeline<IConcreteTypeBuilder, EntityContext> entityPipeline, IPipeline<IConcreteTypeBuilder, OverrideEntityContext> overrideEntityPipeline, IPipeline<TypeBaseBuilder, ReflectionContext> reflectionPipeline, IPipeline<InterfaceBuilder, InterfaceContext> interfacePipeline) : base(csharpExpressionCreator, builderPipeline, builderExtensionPipeline, entityPipeline, overrideEntityPipeline, reflectionPipeline, interfacePipeline)
+    {
+    }
+
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "Test.Domain");
+
+    public override string Path => "Test.Domain";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCSharpClassBase.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCSharpClassBase.cs
@@ -6,6 +6,6 @@ public abstract class ImmutablePrivateSettersCSharpClassBase : ImmutableCSharpCl
     {
     }
 
-    protected override Domain.Domains.SubVisibility SetterVisibility => Domain.Domains.SubVisibility.Private;
+    protected override SubVisibility SetterVisibility => SubVisibility.Private;
     protected override bool AddSetters => true;
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
@@ -6,7 +6,7 @@ public class ImmutablePrivateSettersCoreEntities : ImmutablePrivateSettersCSharp
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetCoreModels(), "Test.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableSharedValidationCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableSharedValidationCoreEntities.cs
@@ -6,7 +6,7 @@ public class ImmutableSharedValidationCoreEntities : ImmutableSharedValidationCS
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetCoreModels(), "Test.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
@@ -6,7 +6,7 @@ public class ObservableCoreEntities : ObservableCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetCoreModels(), "Test.Domain");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -6,7 +6,7 @@ public class TemplateFrameworkEntities : ImmutableCSharpClassBase
     {
     }
 
-    public override IEnumerable<TypeBase> Model => GetImmutableClasses(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
+    public override IEnumerable<TypeBase> Model => GetEntities(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
@@ -27,6 +27,8 @@ public sealed class IntegrationTests : TestBase, IDisposable
             .AddScoped<ImmutablePrivateSettersCoreEntities>()
             .AddScoped<ImmutableSharedValidationCoreBuilders>()
             .AddScoped<ImmutableSharedValidationCoreEntities>()
+            .AddScoped<ImmutableInheritFromInterfacesCoreBuilders>()
+            .AddScoped<ImmutableInheritFromInterfacesCoreEntities>()
             .AddScoped<ObservableCoreBuilders>()
             .AddScoped<ObservableCoreEntities>()
             .AddScoped<TemplateFrameworkEntities>()
@@ -594,6 +596,141 @@ namespace Test.Domain.Builders
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
             System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance), results, true);
             return results;
+        }
+    }
+#nullable restore
+}
+");
+    }
+
+    [Fact]
+    public void Can_Generate_Code_For_Immutable_Entity_InheritFromInterfaces_With_PipelineCodeGenerationProviderBase()
+    {
+        // Arrange
+        var engine = _scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
+        var codeGenerationProvider = _scope.ServiceProvider.GetRequiredService<ImmutableInheritFromInterfacesCoreEntities>();
+        var generationEnvironment = new MultipleContentBuilderEnvironment();
+        var codeGenerationSettings = new CodeGenerationSettings(string.Empty, "GeneratedCode.cs", dryRun: true);
+
+        // Act
+        engine.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+        // Assert
+        generationEnvironment.Builder.Contents.Should().ContainSingle();
+        generationEnvironment.Builder.Contents.First().Builder.ToString().Should().Be(@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test.Domain
+{
+#nullable enable
+    public partial class Literal : Test.Domain.Abstractions.ILiteral
+    {
+        [System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings = true)]
+        public string Value
+        {
+            get;
+        }
+
+        public object? OriginalValue
+        {
+            get;
+        }
+
+        public Literal(string value, object? originalValue)
+        {
+            this.Value = value;
+            this.OriginalValue = originalValue;
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
+
+        public Test.Abstractions.Builders.ILiteralBuilder ToBuilder()
+        {
+            return new Test.Domain.Builders.LiteralBuilder(this);
+        }
+    }
+#nullable restore
+}
+");
+    }
+
+    [Fact]
+    public void Can_Generate_Code_For_Immutable_Builder_InheritFromInterfaces_With_PipelineCodeGenerationProviderBase()
+    {
+        // Arrange
+        var engine = _scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
+        var codeGenerationProvider = _scope.ServiceProvider.GetRequiredService<ImmutableInheritFromInterfacesCoreBuilders>();
+        var generationEnvironment = new MultipleContentBuilderEnvironment();
+        var codeGenerationSettings = new CodeGenerationSettings(string.Empty, "GeneratedCode.cs", dryRun: true);
+
+        // Act
+        engine.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+        // Assert
+        generationEnvironment.Builder.Contents.Should().ContainSingle();
+        generationEnvironment.Builder.Contents.First().Builder.ToString().Should().Be(@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test.Domain.Builders
+{
+#nullable enable
+    public partial class LiteralBuilder : Test.Domain.Builders.Abstractions.ILiteralBuilder
+    {
+        private string _value;
+
+        [System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings = true)]
+        public string Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value ?? throw new System.ArgumentNullException(nameof(value));
+            }
+        }
+
+        public object? OriginalValue
+        {
+            get;
+            set;
+        }
+
+        public LiteralBuilder(Test.Abstractions.ILiteral source)
+        {
+            if (source is null) throw new System.ArgumentNullException(nameof(source));
+            _value = source.Value;
+            OriginalValue = source.OriginalValue;
+        }
+
+        public LiteralBuilder()
+        {
+            _value = string.Empty;
+            SetDefaultValues();
+        }
+
+        public Test.Domain.Abstractions.ILiteral Build()
+        {
+            return new Test.Domain.Literal(Value, OriginalValue);
+        }
+
+        partial void SetDefaultValues();
+
+        public Test.Domain.Builders.LiteralBuilder WithValue(string value)
+        {
+            if (value is null) throw new System.ArgumentNullException(nameof(value));
+            Value = value;
+            return this;
+        }
+
+        public Test.Domain.Builders.LiteralBuilder WithOriginalValue(object? originalValue)
+        {
+            OriginalValue = originalValue;
+            return this;
         }
     }
 #nullable restore

--- a/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
@@ -31,6 +31,7 @@ public sealed class IntegrationTests : TestBase, IDisposable
             .AddScoped<ImmutableInheritFromInterfacesCoreEntities>()
             .AddScoped<ImmutableInheritFromInterfacesAbstractionsInterfaces>()
             .AddScoped<ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces>()
+            .AddScoped<ImmutableNoToBuilderMethodCoreEntities>()
             .AddScoped<ObservableCoreBuilders>()
             .AddScoped<ObservableCoreEntities>()
             .AddScoped<TemplateFrameworkEntities>()
@@ -820,6 +821,53 @@ namespace Test.Abstractions
         }
 
         Test.Abstractions.ILiteral Build();
+    }
+#nullable restore
+}
+");
+    }
+
+    [Fact]
+    public void Can_Generate_Code_For_Immutable_Entity_NoToBuilderMethod_With_PipelineCodeGenerationProviderBase()
+    {
+        // Arrange
+        var engine = _scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
+        var codeGenerationProvider = _scope.ServiceProvider.GetRequiredService<ImmutableNoToBuilderMethodCoreEntities>();
+        var generationEnvironment = new MultipleContentBuilderEnvironment();
+        var codeGenerationSettings = new CodeGenerationSettings(string.Empty, "GeneratedCode.cs", dryRun: true);
+
+        // Act
+        engine.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+        // Assert
+        generationEnvironment.Builder.Contents.Should().ContainSingle();
+        generationEnvironment.Builder.Contents.First().Builder.ToString().Should().Be(@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test.Domain
+{
+#nullable enable
+    public partial class Literal
+    {
+        [System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings = true)]
+        public string Value
+        {
+            get;
+        }
+
+        public object? OriginalValue
+        {
+            get;
+        }
+
+        public Literal(string value, object? originalValue)
+        {
+            this.Value = value;
+            this.OriginalValue = originalValue;
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
     }
 #nullable restore
 }

--- a/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
@@ -29,6 +29,8 @@ public sealed class IntegrationTests : TestBase, IDisposable
             .AddScoped<ImmutableSharedValidationCoreEntities>()
             .AddScoped<ImmutableInheritFromInterfacesCoreBuilders>()
             .AddScoped<ImmutableInheritFromInterfacesCoreEntities>()
+            .AddScoped<ImmutableInheritFromInterfacesAbstractionsInterfaces>()
+            .AddScoped<ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces>()
             .AddScoped<ObservableCoreBuilders>()
             .AddScoped<ObservableCoreEntities>()
             .AddScoped<TemplateFrameworkEntities>()
@@ -732,6 +734,92 @@ namespace Test.Domain.Builders
             OriginalValue = originalValue;
             return this;
         }
+    }
+#nullable restore
+}
+");
+    }
+
+    [Fact]
+    public void Can_Generate_Code_For_Immutable_EntityInterface_InheritFromInterfaces_With_PipelineCodeGenerationProviderBase()
+    {
+        // Arrange
+        var engine = _scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
+        var codeGenerationProvider = _scope.ServiceProvider.GetRequiredService<ImmutableInheritFromInterfacesAbstractionsInterfaces>();
+        var generationEnvironment = new MultipleContentBuilderEnvironment();
+        var codeGenerationSettings = new CodeGenerationSettings(string.Empty, "GeneratedCode.cs", dryRun: true);
+
+        // Act
+        engine.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+        // Assert
+        generationEnvironment.Builder.Contents.Should().ContainSingle();
+        generationEnvironment.Builder.Contents.First().Builder.ToString().Should().Be(@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test.Abstractions
+{
+#nullable enable
+    public interface ILiteral
+    {
+        [System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings = true)]
+        string Value
+        {
+            get;
+        }
+
+        object? OriginalValue
+        {
+            get;
+        }
+
+        Test.Abstractions.Builders.ILiteralBuilder ToBuilder();
+    }
+#nullable restore
+}
+");
+    }
+
+    [Fact]
+    public void Can_Generate_Code_For_Immutable_BuilderInterface_InheritFromInterfaces_With_PipelineCodeGenerationProviderBase()
+    {
+        // Arrange
+        var engine = _scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
+        var codeGenerationProvider = _scope.ServiceProvider.GetRequiredService<ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces>();
+        var generationEnvironment = new MultipleContentBuilderEnvironment();
+        var codeGenerationSettings = new CodeGenerationSettings(string.Empty, "GeneratedCode.cs", dryRun: true);
+
+        // Act
+        engine.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+        // Assert
+        generationEnvironment.Builder.Contents.Should().ContainSingle();
+        generationEnvironment.Builder.Contents.First().Builder.ToString().Should().Be(@"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test.Abstractions
+{
+#nullable enable
+    public interface ILiteralBuilder
+    {
+        [System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings = true)]
+        string Value
+        {
+            get;
+            set;
+        }
+
+        object? OriginalValue
+        {
+            get;
+            set;
+        }
+
+        Test.Abstractions.ILiteral Build();
     }
 #nullable restore
 }

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -449,6 +449,8 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                         (
                             new MetadataBuilder().WithValue($"{CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}").WithName(Pipelines.MetadataNames.CustomBuilderNamespace),
                             new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(Pipelines.MetadataNames.CustomBuilderName),
+                            new MetadataBuilder().WithValue($"{ProjectName}.Abstractions.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}").WithName(Pipelines.MetadataNames.CustomBuilderInterfaceNamespace),
+                            new MetadataBuilder().WithValue("I{TypeName.ClassName}Builder").WithName(Pipelines.MetadataNames.CustomBuilderInterfaceName),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models" && x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions"
                                 ? $"new {CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}.{x.GetEntityClassName()}Builder([Name])"
                                 : "[Name][NullableSuffix].ToBuilder()").WithName(Pipelines.MetadataNames.CustomBuilderSourceExpression),

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -449,7 +449,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                         (
                             new MetadataBuilder().WithValue($"{CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}").WithName(Pipelines.MetadataNames.CustomBuilderNamespace),
                             new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(Pipelines.MetadataNames.CustomBuilderName),
-                            new MetadataBuilder().WithValue($"{ProjectName}.Abstractions.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}").WithName(Pipelines.MetadataNames.CustomBuilderInterfaceNamespace),
+                            new MetadataBuilder().WithValue($"{ProjectName}.Abstractions.Builders").WithName(Pipelines.MetadataNames.CustomBuilderInterfaceNamespace),
                             new MetadataBuilder().WithValue("I{TypeName.ClassName}Builder").WithName(Pipelines.MetadataNames.CustomBuilderInterfaceName),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models" && x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions"
                                 ? $"new {CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}.{x.GetEntityClassName()}Builder([Name])"

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -450,7 +450,8 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                                 //: $"builderFactory.Create<{CoreNamespace}.Builders.{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", true)}{x.GetEntityClassName()}Builder>([Name])", Pipelines.MetadataNames.CustomBuilderSourceExpression),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models" && x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions"
                                 ? "[Name][NullableSuffix].BuildTyped()"
-                                : "[Name][NullableSuffix].Build()").WithName(Pipelines.MetadataNames.CustomBuilderMethodParameterExpression)
+                                : "[Name][NullableSuffix].Build()").WithName(Pipelines.MetadataNames.CustomBuilderMethodParameterExpression),
+                            new MetadataBuilder().WithName(Pipelines.MetadataNames.CustomEntityInterfaceTypeName).WithValue($"{ProjectName}.Abstractions.{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", true)}I{x.GetEntityClassName()}")
                             //new MetadataBuilder().WithValue(new ParameterBuilder().WithName("builderFactory").WithTypeName($"{CoreNamespace}.Builders.Abstractions.IBuilderFactory").Build()).WithName(Pipelines.MetadataNames.CustomBuilderCopyConstructorParameter),
                         )
                 })

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -230,7 +230,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         Guard.IsNotNull(interfacesNamespace);
 
         return GetBuilders(models, buildersNamespace, entitiesNamespace)
-            .Select(x => CreateInterface(x, interfacesNamespace, EntityConcreteCollectionType.WithoutGenerics(), true, "I{Class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0))
+            .Select(x => CreateInterface(x, interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{Class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0))
             .ToArray();
     }
 

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -59,6 +59,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual bool CopyAttributes => false;
     protected virtual bool CopyInterfaces => false;
     protected virtual bool CopyMethods => false;
+    protected virtual bool InheritFromInterfaces => false;
     protected virtual bool AddNullChecks => true;
     protected virtual bool UseExceptionThrowIfNull => false;
     protected virtual bool CreateRecord => false;
@@ -269,6 +270,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .WithCopyAttributes(CopyAttributes)
             .WithCopyInterfaces(CopyInterfaces)
             .WithCopyMethods(CopyMethods)
+            .WithInheritFromInterfaces(InheritFromInterfaces)
             .WithCopyAttributePredicate(CopyAttributePredicate)
             .WithCopyInterfacePredicate(CopyInterfacePredicate)
             .WithCopyMethodPredicate(CopyMethodPredicate)
@@ -309,6 +311,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .WithCopyAttributes(CopyAttributes)
             .WithCopyInterfaces(CopyInterfaces)
             .WithCopyMethods(CopyMethods)
+            .WithInheritFromInterfaces(InheritFromInterfaces)
             .WithCopyAttributePredicate(CopyAttributePredicate)
             .WithCopyInterfacePredicate(CopyInterfacePredicate)
             .WithCopyMethodPredicate(CopyMethodPredicate)
@@ -331,6 +334,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .WithCopyAttributes(CopyAttributes)
             .WithCopyInterfaces(CopyInterfaces)
             .WithCopyMethods(CopyMethods)
+            .WithInheritFromInterfaces(InheritFromInterfaces)
             .WithCopyAttributePredicate(CopyAttributePredicate)
             .WithCopyInterfacePredicate(CopyInterfacePredicate)
             .WithCopyMethodPredicate(CopyMethodPredicate)
@@ -396,6 +400,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .WithCopyAttributes(CopyAttributes)
             .WithCopyInterfaces(CopyInterfaces)
             .WithCopyMethods(CopyMethods)
+            .WithInheritFromInterfaces(InheritFromInterfaces)
             .WithCopyAttributePredicate(CopyAttributePredicate)
             .WithCopyInterfacePredicate(CopyInterfacePredicate)
             .WithCopyMethodPredicate(CopyMethodPredicate)

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -1,4 +1,6 @@
-﻿namespace ClassFramework.TemplateFramework.CodeGenerationProviders;
+﻿using ClassFramework.Domain;
+
+namespace ClassFramework.TemplateFramework.CodeGenerationProviders;
 
 public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : CsharpClassGeneratorCodeGenerationProviderBase
 {
@@ -86,7 +88,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual bool CreateCodeGenerationHeader => true;
     protected virtual Predicate<Domain.Attribute>? CopyAttributePredicate => null;
     protected virtual Predicate<string>? CopyInterfacePredicate => null;
-    protected virtual Predicate<Method>? CopyMethodPredicate => null;
+    protected virtual Func<IType, Method, bool>? CopyMethodPredicate => null;
     protected virtual Func<IParentTypeContainer, IType, bool>? InheritanceComparisonDelegate => new Func<IParentTypeContainer, IType, bool>((parentNameContainer, typeBase)
         => parentNameContainer is not null
         && typeBase is not null

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -456,7 +456,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models" && x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions"
                                 ? "[Name][NullableSuffix].BuildTyped()"
                                 : "[Name][NullableSuffix].Build()").WithName(Pipelines.MetadataNames.CustomBuilderMethodParameterExpression),
-                            new MetadataBuilder().WithName(Pipelines.MetadataNames.CustomEntityInterfaceTypeName).WithValue($"{ProjectName}.Abstractions.{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", true)}I{x.GetEntityClassName()}")
+                            new MetadataBuilder().WithName(Pipelines.MetadataNames.CustomEntityInterfaceTypeName).WithValue($"{ProjectName}.Abstractions.I{x.GetEntityClassName()}")
                             //new MetadataBuilder().WithValue(new ParameterBuilder().WithName("builderFactory").WithTypeName($"{CoreNamespace}.Builders.Abstractions.IBuilderFactory").Build()).WithName(Pipelines.MetadataNames.CustomBuilderCopyConstructorParameter),
                         )
                 })

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -1,6 +1,4 @@
-﻿using ClassFramework.Domain;
-
-namespace ClassFramework.TemplateFramework.CodeGenerationProviders;
+﻿namespace ClassFramework.TemplateFramework.CodeGenerationProviders;
 
 public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : CsharpClassGeneratorCodeGenerationProviderBase
 {

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -126,7 +126,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected string GetEntityClassName(string className)
         => Array.Find(GetCustomBuilderTypes(), x => className.EndsWith(x, StringComparison.InvariantCulture)) ?? string.Empty;
 
-    protected TypeBase[] GetImmutableClasses(TypeBase[] models, string entitiesNamespace)
+    protected TypeBase[] GetEntities(TypeBase[] models, string entitiesNamespace)
     {
         Guard.IsNotNull(models);
         Guard.IsNotNull(entitiesNamespace);
@@ -138,7 +138,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                 x => new[]
                 {
                     CreateImmutableClass(x, entitiesNamespace),
-                    CreateImmutableOverrideClass(x, entitiesNamespace)
+                    CreateOverrideEntities(x, entitiesNamespace)
                 }
             ).ToArray();
         }
@@ -599,7 +599,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         return builder.Build();
     }
 
-    private TypeBase CreateImmutableOverrideClass(TypeBase typeBase, string entitiesNamespace)
+    private TypeBase CreateOverrideEntities(TypeBase typeBase, string entitiesNamespace)
     {
         var builder = new ClassBuilder();
         _ = _overrideEntityPipeline

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -147,6 +147,18 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         ).ToArray();
     }
 
+    protected TypeBase[] GetEntityInterfaces(TypeBase[] models, string entitiesNamespace, string interfacesNamespace)
+    {
+        Guard.IsNotNull(models);
+        Guard.IsNotNull(entitiesNamespace);
+        Guard.IsNotNull(interfacesNamespace);
+
+        return models
+            .Select(x => CreateImmutableClass(x, entitiesNamespace))
+            .Select(x => CreateInterface(x, interfacesNamespace, string.Empty, true, "I{Class.Name}"))
+            .ToArray();
+    }
+
     protected TypeBase[] GetInterfaces(TypeBase[] models, string interfacesNamespace)
     {
         Guard.IsNotNull(models);

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -53,7 +53,9 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected abstract Type BuilderCollectionType { get; }
 
     protected virtual string EnvironmentVersion => string.Empty;
-    protected virtual string RootNamespace => $"{ProjectName}.Domain";
+    protected virtual string RootNamespace => InheritFromInterfaces
+        ? $"{ProjectName}.Abstractions"
+        : CoreNamespace;
     protected virtual string CodeGenerationRootNamespace => $"{ProjectName}.CodeGeneration";
     protected virtual string CoreNamespace => $"{ProjectName}.Core";
     protected virtual bool CopyAttributes => false;
@@ -97,7 +99,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             || (BaseClass is not null && !BaseClass.Properties.Any(x => x.Name == (parentNameContainer as INameContainer)?.Name))
             || parentNameContainer.ParentTypeFullName.GetClassName().In(typeBase.Name, $"I{typeBase.Name}")
             || Array.Exists(GetModelAbstractBaseTyped(), x => x == parentNameContainer.ParentTypeFullName.GetClassName())
-            || (parentNameContainer.ParentTypeFullName.StartsWith($"{RootNamespace}.Abstractions.") && typeBase.Namespace == RootNamespace)
+            || (parentNameContainer.ParentTypeFullName.StartsWith($"{RootNamespace}.") && typeBase.Namespace == RootNamespace)
         ));
 
     protected virtual string[] GetModelAbstractBaseTyped() => Array.Empty<string>();
@@ -300,7 +302,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                     && (string.IsNullOrEmpty(parentNameContainer.ParentTypeFullName)
                         || parentNameContainer.ParentTypeFullName.GetClassName().In(typeBase.Name, $"I{typeBase.Name}")
                         || Array.Exists(GetModelAbstractBaseTyped(), x => x == parentNameContainer.ParentTypeFullName.GetClassName())
-                        || (parentNameContainer.ParentTypeFullName.StartsWith($"{RootNamespace}.Abstractions.") && typeBase.Namespace == RootNamespace)
+                        || (parentNameContainer.ParentTypeFullName.StartsWith($"{RootNamespace}.") && typeBase.Namespace == RootNamespace)
                     ))
             .WithEntityNewCollectionTypeName(EntityCollectionType.WithoutGenerics())
             .WithEnableNullableReferenceTypes()


### PR DESCRIPTION
Added new functionality: Interface pipeline should also copy methods. This can be used to generate methods on the interface, like Build on an builder interface.

This PR also includes functionality to inherit from interfaces. In other words: You can now generate interfaces for your entities, and inherit from them. This allows you to create separate packages for interfaces (or contracts/abstractions) and your core implementation.