### PR TITLE
vnext

### DIFF
--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
@@ -63,8 +63,8 @@ public abstract class ClassFrameworkCSharpClassBase : CsharpClassGeneratorPipeli
                 (
                     new MetadataBuilder().WithValue(builderNamespace).WithName(Pipelines.MetadataNames.CustomBuilderNamespace),
                     new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(Pipelines.MetadataNames.CustomBuilderName),
-                    new MetadataBuilder().WithValue("[Name][NullableSuffix].ToBuilder()").WithName(Pipelines.MetadataNames.CustomBuilderSourceExpression),
-                    new MetadataBuilder().WithValue("[Name][NullableSuffix].Build()").WithName(Pipelines.MetadataNames.CustomBuilderMethodParameterExpression)
+                    new MetadataBuilder().WithValue("[Name][NullableSuffix].ToBuilder()[ForcedNullableSuffix]").WithName(Pipelines.MetadataNames.CustomBuilderSourceExpression),
+                    new MetadataBuilder().WithValue("[Name][NullableSuffix].Build()[ForcedNullableSuffix]").WithName(Pipelines.MetadataNames.CustomBuilderMethodParameterExpression)
                 ),
         ];
 

--- a/src/ClassFramework.Domain/Builders/AbstractNonGenericBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/AbstractNonGenericBuilders.template.generated.cs
@@ -251,12 +251,12 @@ namespace ClassFramework.Domain.Builders
             _namespace = source.Namespace;
             _partial = source.Partial;
             foreach (var item in source.Interfaces) _interfaces.Add(item);
-            foreach (var item in source.Fields.Select(x => x.ToBuilder())) _fields.Add(item);
-            foreach (var item in source.Properties.Select(x => x.ToBuilder())) _properties.Add(item);
-            foreach (var item in source.Methods.Select(x => x.ToBuilder())) _methods.Add(item);
+            foreach (var item in source.Fields.Select(x => x.ToBuilder()!)) _fields.Add(item);
+            foreach (var item in source.Properties.Select(x => x.ToBuilder()!)) _properties.Add(item);
+            foreach (var item in source.Methods.Select(x => x.ToBuilder()!)) _methods.Add(item);
             _visibility = source.Visibility;
             _name = source.Name;
-            foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             foreach (var item in source.GenericTypeArguments) _genericTypeArguments.Add(item);
             foreach (var item in source.GenericTypeArgumentConstraints) _genericTypeArgumentConstraints.Add(item);
             foreach (var item in source.SuppressWarningCodes) _suppressWarningCodes.Add(item);

--- a/src/ClassFramework.Domain/Builders/AbstractNonGenericBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/AbstractNonGenericBuilders.template.generated.cs
@@ -251,12 +251,12 @@ namespace ClassFramework.Domain.Builders
             _namespace = source.Namespace;
             _partial = source.Partial;
             foreach (var item in source.Interfaces) _interfaces.Add(item);
-            foreach (var item in source.Fields.Select(x => x.ToBuilder()!)) _fields.Add(item);
-            foreach (var item in source.Properties.Select(x => x.ToBuilder()!)) _properties.Add(item);
-            foreach (var item in source.Methods.Select(x => x.ToBuilder()!)) _methods.Add(item);
+            foreach (var item in source.Fields.Select(x => x.ToBuilder())) _fields.Add(item);
+            foreach (var item in source.Properties.Select(x => x.ToBuilder())) _properties.Add(item);
+            foreach (var item in source.Methods.Select(x => x.ToBuilder())) _methods.Add(item);
             _visibility = source.Visibility;
             _name = source.Name;
-            foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             foreach (var item in source.GenericTypeArguments) _genericTypeArguments.Add(item);
             foreach (var item in source.GenericTypeArgumentConstraints) _genericTypeArgumentConstraints.Add(item);
             foreach (var item in source.SuppressWarningCodes) _suppressWarningCodes.Add(item);

--- a/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
@@ -56,7 +56,7 @@ namespace ClassFramework.Domain.Builders
         {
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _parameters = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeParameterBuilder>();
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
             _name = source.Name;
         }
 
@@ -365,9 +365,9 @@ namespace ClassFramework.Domain.Builders
             _protected = source.Protected;
             _override = source.Override;
             _visibility = source.Visibility;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
-            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder()!)) _codeStatements.Add(item);
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder())) _codeStatements.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
             if (source.SuppressWarningCodes is not null) foreach (var item in source.SuppressWarningCodes) _suppressWarningCodes.Add(item);
         }
 
@@ -562,8 +562,8 @@ namespace ClassFramework.Domain.Builders
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _members = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.EnumerationMemberBuilder>();
             _attributes = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeBuilder>();
-            if (source.Members is not null) foreach (var item in source.Members.Select(x => x.ToBuilder()!)) _members.Add(item);
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.Members is not null) foreach (var item in source.Members.Select(x => x.ToBuilder())) _members.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             _name = source.Name;
             _visibility = source.Visibility;
         }
@@ -684,7 +684,7 @@ namespace ClassFramework.Domain.Builders
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _attributes = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeBuilder>();
             _value = source.Value;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             _name = source.Name;
         }
 
@@ -996,7 +996,7 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;
@@ -1576,9 +1576,9 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
-            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder()!)) _codeStatements.Add(item);
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder())) _codeStatements.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
             _explicitInterfaceName = source.ExplicitInterfaceName;
             _parentTypeFullName = source.ParentTypeFullName;
             if (source.GenericTypeArguments is not null) foreach (var item in source.GenericTypeArguments) _genericTypeArguments.Add(item);
@@ -1944,7 +1944,7 @@ namespace ClassFramework.Domain.Builders
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             _name = source.Name;
             _defaultValue = source.DefaultValue;
         }
@@ -2408,9 +2408,9 @@ namespace ClassFramework.Domain.Builders
             _getterVisibility = source.GetterVisibility;
             _setterVisibility = source.SetterVisibility;
             _initializerVisibility = source.InitializerVisibility;
-            if (source.GetterCodeStatements is not null) foreach (var item in source.GetterCodeStatements.Select(x => x.ToBuilder()!)) _getterCodeStatements.Add(item);
-            if (source.SetterCodeStatements is not null) foreach (var item in source.SetterCodeStatements.Select(x => x.ToBuilder()!)) _setterCodeStatements.Add(item);
-            if (source.InitializerCodeStatements is not null) foreach (var item in source.InitializerCodeStatements.Select(x => x.ToBuilder()!)) _initializerCodeStatements.Add(item);
+            if (source.GetterCodeStatements is not null) foreach (var item in source.GetterCodeStatements.Select(x => x.ToBuilder())) _getterCodeStatements.Add(item);
+            if (source.SetterCodeStatements is not null) foreach (var item in source.SetterCodeStatements.Select(x => x.ToBuilder())) _setterCodeStatements.Add(item);
+            if (source.InitializerCodeStatements is not null) foreach (var item in source.InitializerCodeStatements.Select(x => x.ToBuilder())) _initializerCodeStatements.Add(item);
             _static = source.Static;
             _virtual = source.Virtual;
             _abstract = source.Abstract;
@@ -2418,7 +2418,7 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;

--- a/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
@@ -56,7 +56,7 @@ namespace ClassFramework.Domain.Builders
         {
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _parameters = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeParameterBuilder>();
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
             _name = source.Name;
         }
 
@@ -69,7 +69,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Attribute Build()
         {
-            return new ClassFramework.Domain.Attribute(Parameters.Select(x => x.Build()).ToList().AsReadOnly(), Name);
+            return new ClassFramework.Domain.Attribute(Parameters.Select(x => x.Build()!).ToList().AsReadOnly(), Name);
         }
 
         partial void SetDefaultValues();
@@ -365,9 +365,9 @@ namespace ClassFramework.Domain.Builders
             _protected = source.Protected;
             _override = source.Override;
             _visibility = source.Visibility;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
-            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder())) _codeStatements.Add(item);
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder()!)) _codeStatements.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
             if (source.SuppressWarningCodes is not null) foreach (var item in source.SuppressWarningCodes) _suppressWarningCodes.Add(item);
         }
 
@@ -383,7 +383,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Constructor Build()
         {
-            return new ClassFramework.Domain.Constructor(ChainCall, Static, Virtual, Abstract, Protected, Override, Visibility, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), CodeStatements.Select(x => x.Build()).ToList().AsReadOnly(), Parameters.Select(x => x.Build()).ToList().AsReadOnly(), SuppressWarningCodes);
+            return new ClassFramework.Domain.Constructor(ChainCall, Static, Virtual, Abstract, Protected, Override, Visibility, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), CodeStatements.Select(x => x.Build()!).ToList().AsReadOnly(), Parameters.Select(x => x.Build()!).ToList().AsReadOnly(), SuppressWarningCodes);
         }
 
         partial void SetDefaultValues();
@@ -562,8 +562,8 @@ namespace ClassFramework.Domain.Builders
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _members = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.EnumerationMemberBuilder>();
             _attributes = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeBuilder>();
-            if (source.Members is not null) foreach (var item in source.Members.Select(x => x.ToBuilder())) _members.Add(item);
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.Members is not null) foreach (var item in source.Members.Select(x => x.ToBuilder()!)) _members.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             _name = source.Name;
             _visibility = source.Visibility;
         }
@@ -578,7 +578,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Enumeration Build()
         {
-            return new ClassFramework.Domain.Enumeration(Members.Select(x => x.Build()).ToList().AsReadOnly(), Attributes.Select(x => x.Build()).ToList().AsReadOnly(), Name, Visibility);
+            return new ClassFramework.Domain.Enumeration(Members.Select(x => x.Build()!).ToList().AsReadOnly(), Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), Name, Visibility);
         }
 
         partial void SetDefaultValues();
@@ -684,7 +684,7 @@ namespace ClassFramework.Domain.Builders
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _attributes = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.AttributeBuilder>();
             _value = source.Value;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             _name = source.Name;
         }
 
@@ -697,7 +697,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.EnumerationMember Build()
         {
-            return new ClassFramework.Domain.EnumerationMember(Value, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), Name);
+            return new ClassFramework.Domain.EnumerationMember(Value, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), Name);
         }
 
         partial void SetDefaultValues();
@@ -996,7 +996,7 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;
@@ -1015,7 +1015,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Field Build()
         {
-            return new ClassFramework.Domain.Field(ReadOnly, Constant, Event, Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), TypeName, IsNullable, IsValueType, DefaultValue, ParentTypeFullName);
+            return new ClassFramework.Domain.Field(ReadOnly, Constant, Event, Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), TypeName, IsNullable, IsValueType, DefaultValue, ParentTypeFullName);
         }
 
         partial void SetDefaultValues();
@@ -1576,9 +1576,9 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
-            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder())) _codeStatements.Add(item);
-            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder())) _parameters.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
+            if (source.CodeStatements is not null) foreach (var item in source.CodeStatements.Select(x => x.ToBuilder()!)) _codeStatements.Add(item);
+            if (source.Parameters is not null) foreach (var item in source.Parameters.Select(x => x.ToBuilder()!)) _parameters.Add(item);
             _explicitInterfaceName = source.ExplicitInterfaceName;
             _parentTypeFullName = source.ParentTypeFullName;
             if (source.GenericTypeArguments is not null) foreach (var item in source.GenericTypeArguments) _genericTypeArguments.Add(item);
@@ -1603,7 +1603,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Method Build()
         {
-            return new ClassFramework.Domain.Method(ReturnTypeName, ReturnTypeIsNullable, ReturnTypeIsValueType, Partial, ExtensionMethod, Operator, Async, Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), CodeStatements.Select(x => x.Build()).ToList().AsReadOnly(), Parameters.Select(x => x.Build()).ToList().AsReadOnly(), ExplicitInterfaceName, ParentTypeFullName, GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes);
+            return new ClassFramework.Domain.Method(ReturnTypeName, ReturnTypeIsNullable, ReturnTypeIsValueType, Partial, ExtensionMethod, Operator, Async, Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), CodeStatements.Select(x => x.Build()!).ToList().AsReadOnly(), Parameters.Select(x => x.Build()!).ToList().AsReadOnly(), ExplicitInterfaceName, ParentTypeFullName, GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes);
         }
 
         partial void SetDefaultValues();
@@ -1944,7 +1944,7 @@ namespace ClassFramework.Domain.Builders
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             _name = source.Name;
             _defaultValue = source.DefaultValue;
         }
@@ -1959,7 +1959,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Parameter Build()
         {
-            return new ClassFramework.Domain.Parameter(IsParamArray, IsOut, IsRef, TypeName, IsNullable, IsValueType, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), Name, DefaultValue);
+            return new ClassFramework.Domain.Parameter(IsParamArray, IsOut, IsRef, TypeName, IsNullable, IsValueType, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), Name, DefaultValue);
         }
 
         partial void SetDefaultValues();
@@ -2408,9 +2408,9 @@ namespace ClassFramework.Domain.Builders
             _getterVisibility = source.GetterVisibility;
             _setterVisibility = source.SetterVisibility;
             _initializerVisibility = source.InitializerVisibility;
-            if (source.GetterCodeStatements is not null) foreach (var item in source.GetterCodeStatements.Select(x => x.ToBuilder())) _getterCodeStatements.Add(item);
-            if (source.SetterCodeStatements is not null) foreach (var item in source.SetterCodeStatements.Select(x => x.ToBuilder())) _setterCodeStatements.Add(item);
-            if (source.InitializerCodeStatements is not null) foreach (var item in source.InitializerCodeStatements.Select(x => x.ToBuilder())) _initializerCodeStatements.Add(item);
+            if (source.GetterCodeStatements is not null) foreach (var item in source.GetterCodeStatements.Select(x => x.ToBuilder()!)) _getterCodeStatements.Add(item);
+            if (source.SetterCodeStatements is not null) foreach (var item in source.SetterCodeStatements.Select(x => x.ToBuilder()!)) _setterCodeStatements.Add(item);
+            if (source.InitializerCodeStatements is not null) foreach (var item in source.InitializerCodeStatements.Select(x => x.ToBuilder()!)) _initializerCodeStatements.Add(item);
             _static = source.Static;
             _virtual = source.Virtual;
             _abstract = source.Abstract;
@@ -2418,7 +2418,7 @@ namespace ClassFramework.Domain.Builders
             _override = source.Override;
             _visibility = source.Visibility;
             _name = source.Name;
-            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder())) _attributes.Add(item);
+            if (source.Attributes is not null) foreach (var item in source.Attributes.Select(x => x.ToBuilder()!)) _attributes.Add(item);
             _typeName = source.TypeName;
             _isNullable = source.IsNullable;
             _isValueType = source.IsValueType;
@@ -2444,7 +2444,7 @@ namespace ClassFramework.Domain.Builders
 
         public ClassFramework.Domain.Property Build()
         {
-            return new ClassFramework.Domain.Property(HasGetter, HasSetter, HasInitializer, GetterVisibility, SetterVisibility, InitializerVisibility, GetterCodeStatements.Select(x => x.Build()).ToList().AsReadOnly(), SetterCodeStatements.Select(x => x.Build()).ToList().AsReadOnly(), InitializerCodeStatements.Select(x => x.Build()).ToList().AsReadOnly(), Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), TypeName, IsNullable, IsValueType, DefaultValue, ExplicitInterfaceName, ParentTypeFullName);
+            return new ClassFramework.Domain.Property(HasGetter, HasSetter, HasInitializer, GetterVisibility, SetterVisibility, InitializerVisibility, GetterCodeStatements.Select(x => x.Build()!).ToList().AsReadOnly(), SetterCodeStatements.Select(x => x.Build()!).ToList().AsReadOnly(), InitializerCodeStatements.Select(x => x.Build()!).ToList().AsReadOnly(), Static, Virtual, Abstract, Protected, Override, Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), TypeName, IsNullable, IsValueType, DefaultValue, ExplicitInterfaceName, ParentTypeFullName);
         }
 
         partial void SetDefaultValues();

--- a/src/ClassFramework.Domain/Builders/Types/OverrideTypeBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/Types/OverrideTypeBuilders.template.generated.cs
@@ -153,11 +153,11 @@ namespace ClassFramework.Domain.Builders.Types
             _static = source.Static;
             _sealed = source.Sealed;
             _abstract = source.Abstract;
-            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder())) _constructors.Add(item);
+            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder()!)) _constructors.Add(item);
             _record = source.Record;
             _baseClass = source.BaseClass;
-            if (source.Enums is not null) foreach (var item in source.Enums.Select(x => x.ToBuilder())) _enums.Add(item);
-            if (source.SubClasses is not null) foreach (var item in source.SubClasses.Select(x => x.ToBuilder())) _subClasses.Add(item);
+            if (source.Enums is not null) foreach (var item in source.Enums.Select(x => x.ToBuilder()!)) _enums.Add(item);
+            if (source.SubClasses is not null) foreach (var item in source.SubClasses.Select(x => x.ToBuilder()!)) _subClasses.Add(item);
         }
 
         public ClassBuilder() : base()
@@ -171,7 +171,7 @@ namespace ClassFramework.Domain.Builders.Types
 
         public override ClassFramework.Domain.Types.Class BuildTyped()
         {
-            return new ClassFramework.Domain.Types.Class(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()).ToList().AsReadOnly(), Properties.Select(x => x.Build()).ToList().AsReadOnly(), Methods.Select(x => x.Build()).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes, Static, Sealed, Abstract, Constructors.Select(x => x.Build()).ToList().AsReadOnly(), Record, BaseClass, Enums.Select(x => x.Build()).ToList().AsReadOnly(), SubClasses.Select(x => x.Build()).ToList().AsReadOnly());
+            return new ClassFramework.Domain.Types.Class(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()!).ToList().AsReadOnly(), Properties.Select(x => x.Build()!).ToList().AsReadOnly(), Methods.Select(x => x.Build()!).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes, Static, Sealed, Abstract, Constructors.Select(x => x.Build()!).ToList().AsReadOnly(), Record, BaseClass, Enums.Select(x => x.Build()!).ToList().AsReadOnly(), SubClasses.Select(x => x.Build()!).ToList().AsReadOnly());
         }
 
         partial void SetDefaultValues();
@@ -260,7 +260,7 @@ namespace ClassFramework.Domain.Builders.Types
 
         public override ClassFramework.Domain.Types.Interface BuildTyped()
         {
-            return new ClassFramework.Domain.Types.Interface(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()).ToList().AsReadOnly(), Properties.Select(x => x.Build()).ToList().AsReadOnly(), Methods.Select(x => x.Build()).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes);
+            return new ClassFramework.Domain.Types.Interface(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()!).ToList().AsReadOnly(), Properties.Select(x => x.Build()!).ToList().AsReadOnly(), Methods.Select(x => x.Build()!).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes);
         }
 
         partial void SetDefaultValues();
@@ -319,7 +319,7 @@ namespace ClassFramework.Domain.Builders.Types
         {
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _constructors = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.ConstructorBuilder>();
-            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder())) _constructors.Add(item);
+            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder()!)) _constructors.Add(item);
             _record = source.Record;
             _baseClass = source.BaseClass;
         }
@@ -333,7 +333,7 @@ namespace ClassFramework.Domain.Builders.Types
 
         public override ClassFramework.Domain.Types.Struct BuildTyped()
         {
-            return new ClassFramework.Domain.Types.Struct(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()).ToList().AsReadOnly(), Properties.Select(x => x.Build()).ToList().AsReadOnly(), Methods.Select(x => x.Build()).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes, Constructors.Select(x => x.Build()).ToList().AsReadOnly(), Record, BaseClass);
+            return new ClassFramework.Domain.Types.Struct(Namespace, Partial, Interfaces, Fields.Select(x => x.Build()!).ToList().AsReadOnly(), Properties.Select(x => x.Build()!).ToList().AsReadOnly(), Methods.Select(x => x.Build()!).ToList().AsReadOnly(), Visibility, Name, Attributes.Select(x => x.Build()!).ToList().AsReadOnly(), GenericTypeArguments, GenericTypeArgumentConstraints, SuppressWarningCodes, Constructors.Select(x => x.Build()!).ToList().AsReadOnly(), Record, BaseClass);
         }
 
         partial void SetDefaultValues();

--- a/src/ClassFramework.Domain/Builders/Types/OverrideTypeBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/Types/OverrideTypeBuilders.template.generated.cs
@@ -153,11 +153,11 @@ namespace ClassFramework.Domain.Builders.Types
             _static = source.Static;
             _sealed = source.Sealed;
             _abstract = source.Abstract;
-            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder()!)) _constructors.Add(item);
+            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder())) _constructors.Add(item);
             _record = source.Record;
             _baseClass = source.BaseClass;
-            if (source.Enums is not null) foreach (var item in source.Enums.Select(x => x.ToBuilder()!)) _enums.Add(item);
-            if (source.SubClasses is not null) foreach (var item in source.SubClasses.Select(x => x.ToBuilder()!)) _subClasses.Add(item);
+            if (source.Enums is not null) foreach (var item in source.Enums.Select(x => x.ToBuilder())) _enums.Add(item);
+            if (source.SubClasses is not null) foreach (var item in source.SubClasses.Select(x => x.ToBuilder())) _subClasses.Add(item);
         }
 
         public ClassBuilder() : base()
@@ -319,7 +319,7 @@ namespace ClassFramework.Domain.Builders.Types
         {
             if (source is null) throw new System.ArgumentNullException(nameof(source));
             _constructors = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Domain.Builders.ConstructorBuilder>();
-            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder()!)) _constructors.Add(item);
+            if (source.Constructors is not null) foreach (var item in source.Constructors.Select(x => x.ToBuilder())) _constructors.Add(item);
             _record = source.Record;
             _baseClass = source.BaseClass;
         }

--- a/src/ClassFramework.Pipelines.Tests/Builder/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Builder/PipelineBuilderTests.cs
@@ -253,8 +253,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<IConcre
             result.Value.Methods.Where(x => x.Name == "Build").Should().ContainSingle();
             var buildMethod = result.Value.Methods.Single(x => x.Name == "Build");
             buildMethod.CodeStatements.Should().AllBeOfType<StringCodeStatementBuilder>();
-            var expected = "return new MyNamespace.MyClass { Property1 = Property1, Property2 = Property2, Property3 = Property3, Property4 = Property4, Property5 = Property5.Build(), Property6 = Property6?.Build(), Property7 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property7.Select(x => x.Build())), Property8 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property8.Select(x => x.Build())) };";
-            buildMethod.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo(expected);
+            buildMethod.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo((string?)"return new MyNamespace.MyClass { Property1 = Property1, Property2 = Property2, Property3 = Property3, Property4 = Property4, Property5 = Property5.Build(), Property6 = Property6?.Build()!, Property7 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property7.Select(x => x.Build()!)), Property8 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property8.Select(x => x.Build()!)) };");
 
             result.Value!.Constructors.Where(x => x.Parameters.Count == 1).Should().ContainSingle();
             var copyConstructor = result.Value.Constructors.Single(x => x.Parameters.Count == 1);
@@ -269,9 +268,9 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<IConcre
                 "_property3 = source.Property3;",
                 "Property4 = source.Property4;",
                 "_property5 = source.Property5.ToBuilder();",
-                "Property6 = source.Property6?.ToBuilder();",
-                "if (source.Property7 is not null) foreach (var item in source.Property7.Select(x => x.ToBuilder())) _property7.Add(item);",
-                "foreach (var item in source.Property8.Select(x => x.ToBuilder())) Property8.Add(item);"
+                "Property6 = source.Property6?.ToBuilder()!;",
+                "if (source.Property7 is not null) foreach (var item in source.Property7.Select(x => x.ToBuilder()!)) _property7.Add(item);",
+                "foreach (var item in source.Property8.Select(x => x.ToBuilder()!)) Property8.Add(item);"
             );
 
             // non-nullable non-value type properties have a backing field, so we can do null checks

--- a/src/ClassFramework.Pipelines.Tests/Builder/PipelineBuilderTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Builder/PipelineBuilderTests.cs
@@ -253,7 +253,7 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<IConcre
             result.Value.Methods.Where(x => x.Name == "Build").Should().ContainSingle();
             var buildMethod = result.Value.Methods.Single(x => x.Name == "Build");
             buildMethod.CodeStatements.Should().AllBeOfType<StringCodeStatementBuilder>();
-            buildMethod.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo((string?)"return new MyNamespace.MyClass { Property1 = Property1, Property2 = Property2, Property3 = Property3, Property4 = Property4, Property5 = Property5.Build(), Property6 = Property6?.Build()!, Property7 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property7.Select(x => x.Build()!)), Property8 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property8.Select(x => x.Build()!)) };");
+            buildMethod.CodeStatements.OfType<StringCodeStatementBuilder>().Select(x => x.Statement).Should().BeEquivalentTo("return new MyNamespace.MyClass { Property1 = Property1, Property2 = Property2, Property3 = Property3, Property4 = Property4, Property5 = Property5?.Build()!, Property6 = Property6?.Build()!, Property7 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property7.Select(x => x.Build()!)), Property8 = new System.Collections.Generic.List<MySourceNamespace.MyClass>(Property8.Select(x => x.Build()!)) };");
 
             result.Value!.Constructors.Where(x => x.Parameters.Count == 1).Should().ContainSingle();
             var copyConstructor = result.Value.Constructors.Single(x => x.Parameters.Count == 1);
@@ -267,10 +267,10 @@ public class PipelineBuilderTests : IntegrationTestBase<IPipelineBuilder<IConcre
                 "Property2 = source.Property2;",
                 "_property3 = source.Property3;",
                 "Property4 = source.Property4;",
-                "_property5 = source.Property5.ToBuilder();",
+                "_property5 = source.Property5?.ToBuilder()!;",
                 "Property6 = source.Property6?.ToBuilder()!;",
-                "if (source.Property7 is not null) foreach (var item in source.Property7.Select(x => x.ToBuilder()!)) _property7.Add(item);",
-                "foreach (var item in source.Property8.Select(x => x.ToBuilder()!)) Property8.Add(item);"
+                "if (source.Property7 is not null) foreach (var item in source.Property7.Select(x => x.ToBuilder())) _property7.Add(item);",
+                "foreach (var item in source.Property8.Select(x => x.ToBuilder())) Property8.Add(item);"
             );
 
             // non-nullable non-value type properties have a backing field, so we can do null checks

--- a/src/ClassFramework.Pipelines.Tests/Extensions/EnumerableOfMetadataExtensionsTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Extensions/EnumerableOfMetadataExtensionsTests.cs
@@ -29,7 +29,7 @@ public class EnumerableOfMetadataExtensionsTests
     }
 
     [Fact]
-    public void GetsFirstValueWhenPresent()
+    public void GetsLastValueWhenPresent()
     {
         // Arrange
         var lst = new[] { new Metadata("value", "name"), new Metadata("second value", "name") };
@@ -38,7 +38,7 @@ public class EnumerableOfMetadataExtensionsTests
         var actual = lst.GetStringValue("name", "default");
 
         // Assert
-        actual.Should().Be("value");
+        actual.Should().Be("second value");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class EnumerableOfMetadataExtensionsTests
         var actual = lst.GetBooleanValue("name");
 
         // Assert
-        actual.Should().BeTrue();
+        actual.Should().BeFalse();
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class EnumerableOfMetadataExtensionsTests
         var lst = new[] { new Metadata(true, "name"), new Metadata(false, "name") };
 
         // Act
-        var actual = lst.GetBooleanValue("name", () => true);
+        var actual = lst.GetBooleanValue("wrong name", () => true);
 
         // Assert
         actual.Should().BeTrue();

--- a/src/ClassFramework.Pipelines.Tests/Extensions/PipelineContextExtensionsTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Extensions/PipelineContextExtensionsTests.cs
@@ -14,9 +14,10 @@ public class PipelineContextExtensionsTests : TestBase
             var builderContext = new BuilderContext(sourceModel, new PipelineSettingsBuilder().Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -33,9 +34,10 @@ public class PipelineContextExtensionsTests : TestBase
             var builderContext = new BuilderContext(sourceModel, new PipelineSettingsBuilder().Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Invalid);
@@ -52,9 +54,10 @@ public class PipelineContextExtensionsTests : TestBase
             var builderContext = new BuilderContext(sourceModel, new PipelineSettingsBuilder().Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.IsSuccessful().Should().BeTrue();
@@ -71,9 +74,10 @@ public class PipelineContextExtensionsTests : TestBase
             var builderContext = new BuilderContext(sourceModel, new PipelineSettingsBuilder().Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.IsSuccessful().Should().BeTrue();
@@ -90,9 +94,10 @@ public class PipelineContextExtensionsTests : TestBase
             var builderContext = new BuilderContext(sourceModel, new PipelineSettingsBuilder().Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.IsSuccessful().Should().BeTrue();
@@ -118,9 +123,10 @@ public class PipelineContextExtensionsTests : TestBase
                 .Build(), Fixture.Freeze<IFormatProvider>());
             var context = new PipelineContext<IConcreteTypeBuilder, BuilderContext>(model, builderContext);
             var formattableStringParser = Fixture.Freeze<IFormattableStringParser>();
+            var csharpExpressionDumper = Fixture.Freeze<ICsharpExpressionDumper>();
 
             // Act
-            var result = context.CreateEntityInstanciation(formattableStringParser, string.Empty);
+            var result = context.CreateEntityInstanciation(formattableStringParser, csharpExpressionDumper, string.Empty);
 
             // Assert
             result.IsSuccessful().Should().BeTrue();

--- a/src/ClassFramework.Pipelines.Tests/Extensions/PropertyExtensionsTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Extensions/PropertyExtensionsTests.cs
@@ -108,9 +108,10 @@ public class PropertyExtensionsTests : TestBase<PropertyBuilder>
         {
             // Arrange
             var sut = CreateSut().WithName("MyProperty").WithType(typeof(string)).Build();
+            var sourceModel = new ClassBuilder().WithName("MyClass").Build();
 
             // Act
-            var result = sut.GetNullCheckSuffix("myProperty", false);
+            var result = sut.GetNullCheckSuffix("myProperty", false, sourceModel);
 
             // Assert
             result.Should().BeEmpty();
@@ -121,9 +122,10 @@ public class PropertyExtensionsTests : TestBase<PropertyBuilder>
         {
             // Arrange
             var sut = CreateSut().WithName("MyProperty").WithType(typeof(string)).WithIsNullable().Build();
+            var sourceModel = new ClassBuilder().WithName("MyClass").Build();
 
             // Act
-            var result = sut.GetNullCheckSuffix("myProperty", true);
+            var result = sut.GetNullCheckSuffix("myProperty", true, sourceModel);
 
             // Assert
             result.Should().BeEmpty();
@@ -134,9 +136,10 @@ public class PropertyExtensionsTests : TestBase<PropertyBuilder>
         {
             // Arrange
             var sut = CreateSut().WithName("MyProperty").WithType(typeof(int)).Build();
+            var sourceModel = new ClassBuilder().WithName("MyClass").Build();
 
             // Act
-            var result = sut.GetNullCheckSuffix("myProperty", true);
+            var result = sut.GetNullCheckSuffix("myProperty", true, sourceModel);
 
             // Assert
             result.Should().BeEmpty();
@@ -147,9 +150,10 @@ public class PropertyExtensionsTests : TestBase<PropertyBuilder>
         {
             // Arrange
             var sut = CreateSut().WithName("MyProperty").WithType(typeof(string)).Build();
+            var sourceModel = new ClassBuilder().WithName("MyClass").Build();
 
             // Act
-            var result = sut.GetNullCheckSuffix("myProperty", true);
+            var result = sut.GetNullCheckSuffix("myProperty", true, sourceModel);
 
             // Assert
             result.Should().Be(" ?? throw new System.ArgumentNullException(nameof(myProperty))");

--- a/src/ClassFramework.Pipelines.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/ClassFramework.Pipelines.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -26,6 +26,7 @@ public class ServiceCollectionExtensionsTests : TestBase
             // Arrange
             var serviceCollection = new ServiceCollection()
                 .AddScoped(_ => Fixture.Freeze<IFormattableStringParser>()) // note that normally, you would probably use AddParsers from the CrossCutting.Utilities.Parsers package...
+                .AddScoped(_ => Fixture.Freeze<ICsharpExpressionDumper>()) // note that normally, you would probably use AddCsharpExpressionDumper from the CsharpDumper package...
                 .AddPipelines();
             using var provider = serviceCollection.BuildServiceProvider();
             using var scope = provider.CreateScope();
@@ -43,6 +44,7 @@ public class ServiceCollectionExtensionsTests : TestBase
             // Arrange
             var serviceCollection = new ServiceCollection()
                 .AddScoped(_ => Fixture.Freeze<IFormattableStringParser>()) // note that normally, you would probably use AddParsers from the CrossCutting.Utilities.Parsers package...
+                .AddScoped(_ => Fixture.Freeze<ICsharpExpressionDumper>()) // note that normally, you would probably use AddCsharpExpressionDumper from the CsharpDumper package...
                 .AddPipelines();
             using var provider = serviceCollection.BuildServiceProvider();
             using var scope = provider.CreateScope();

--- a/src/ClassFramework.Pipelines.Tests/TestBase.cs
+++ b/src/ClassFramework.Pipelines.Tests/TestBase.cs
@@ -357,8 +357,8 @@ public abstract class TestBase : IDisposable
                 .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderNamespace).WithValue("MyNamespace.Builders"))
                 .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderName).WithValue("{TypeName.ClassName}Builder"))
                 .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomEntityNamespace).WithValue("MyNamespace"))
-                .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderSourceExpression).WithValue("[Name][NullableSuffix].ToBuilder()"))
-                .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderMethodParameterExpression).WithValue("[Name][NullableSuffix].Build()"))
+                .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderSourceExpression).WithValue("[Name][NullableSuffix].ToBuilder()[ForcedNullableSuffix]"))
+                .AddMetadata(new MetadataBuilder().WithName(MetadataNames.CustomBuilderMethodParameterExpression).WithValue("[Name][NullableSuffix].Build()[ForcedNullableSuffix]"))
         ];
 
     protected static IEnumerable<TypenameMappingBuilder> CreateTypenameMappings()
@@ -380,7 +380,7 @@ public abstract class TestBase : IDisposable
                     new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(MetadataNames.CustomBuilderName),
                     new MetadataBuilder().WithValue("new ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder(source.[Name])").WithName(MetadataNames.CustomBuilderConstructorInitializeExpression),
                     new MetadataBuilder().WithValue(new Literal("new ExpressionFramework.Domain.Builders.Evaluatables.ComposedEvaluatableBuilder()", null)).WithName(MetadataNames.CustomBuilderDefaultValue),
-                    new MetadataBuilder().WithValue("[Name][NullableSuffix].BuildTyped()").WithName(MetadataNames.CustomBuilderMethodParameterExpression)
+                    new MetadataBuilder().WithValue("[Name][NullableSuffix].BuildTyped()[ForcedNullableSuffix]").WithName(MetadataNames.CustomBuilderMethodParameterExpression)
                 ),
             new TypenameMappingBuilder()
                 .WithSourceTypeName("ExpressionFramework.Domain.Expression")
@@ -391,7 +391,7 @@ public abstract class TestBase : IDisposable
                     new MetadataBuilder().WithValue("{TypeName.ClassName}Builder").WithName(MetadataNames.CustomBuilderName),
                     new MetadataBuilder().WithValue("ExpressionFramework.Domain.Builders.ExpressionBuilderFactory.Create(source.[Name])").WithName(MetadataNames.CustomBuilderConstructorInitializeExpression),
                     new MetadataBuilder().WithValue(new Literal("default(ExpressionFramework.Domain.Builders.ExpressionBuilder)!", null)).WithName(MetadataNames.CustomBuilderDefaultValue),
-                    new MetadataBuilder().WithValue($"[Name][NullableSuffix].Build()").WithName(MetadataNames.CustomBuilderMethodParameterExpression)
+                    new MetadataBuilder().WithValue($"[Name][NullableSuffix].Build()[ForcedNullableSuffix]").WithName(MetadataNames.CustomBuilderMethodParameterExpression)
                 ),
         ];
 

--- a/src/ClassFramework.Pipelines/Builder/Components/AddBuildMethodComponent.cs
+++ b/src/ClassFramework.Pipelines/Builder/Components/AddBuildMethodComponent.cs
@@ -3,23 +3,27 @@
 public class AddBuildMethodComponentBuilder : IBuilderComponentBuilder
 {
     private readonly IFormattableStringParser _formattableStringParser;
+    private readonly ICsharpExpressionDumper _csharpExpressionDumper;
 
-    public AddBuildMethodComponentBuilder(IFormattableStringParser formattableStringParser)
+    public AddBuildMethodComponentBuilder(IFormattableStringParser formattableStringParser, ICsharpExpressionDumper csharpExpressionDumper)
     {
         _formattableStringParser = formattableStringParser.IsNotNull(nameof(formattableStringParser));
+        _csharpExpressionDumper = csharpExpressionDumper.IsNotNull(nameof(csharpExpressionDumper));
     }
 
     public IPipelineComponent<IConcreteTypeBuilder, BuilderContext> Build()
-        => new AddBuildMethodComponent(_formattableStringParser);
+        => new AddBuildMethodComponent(_formattableStringParser, _csharpExpressionDumper);
 }
 
 public class AddBuildMethodComponent : IPipelineComponent<IConcreteTypeBuilder, BuilderContext>
 {
     private readonly IFormattableStringParser _formattableStringParser;
+    private readonly ICsharpExpressionDumper _csharpExpressionDumper;
 
-    public AddBuildMethodComponent(IFormattableStringParser formattableStringParser)
+    public AddBuildMethodComponent(IFormattableStringParser formattableStringParser, ICsharpExpressionDumper csharpExpressionDumper)
     {
         _formattableStringParser = formattableStringParser.IsNotNull(nameof(formattableStringParser));
+        _csharpExpressionDumper = csharpExpressionDumper.IsNotNull(nameof(csharpExpressionDumper));
     }
 
     public Result<IConcreteTypeBuilder> Process(PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
@@ -56,7 +60,7 @@ public class AddBuildMethodComponent : IPipelineComponent<IConcreteTypeBuilder, 
             return Result.Continue<IConcreteTypeBuilder>();
         }
 
-        var instanciationResult = context.CreateEntityInstanciation(_formattableStringParser, string.Empty);
+        var instanciationResult = context.CreateEntityInstanciation(_formattableStringParser, _csharpExpressionDumper, string.Empty);
         if (!instanciationResult.IsSuccessful())
         {
             return Result.FromExistingResult<IConcreteTypeBuilder>(instanciationResult);

--- a/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
+++ b/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
@@ -179,8 +179,9 @@ public class AddCopyConstructorComponent : IPipelineComponent<IConcreteTypeBuild
             return sourceProperty.Name;
         }
 
-        var metadata = context.Context.GetMappingMetadata(sourceProperty.TypeName);
-        var sourceExpression = metadata.GetStringValue(MetadataNames.CustomBuilderSourceExpression, PlaceholderNames.NamePlaceholder);
+        var sourceExpression = context.Context
+            .GetMappingMetadata(sourceProperty.TypeName)
+            .GetStringValue(MetadataNames.CustomBuilderSourceExpression, PlaceholderNames.NamePlaceholder);
         if (sourceProperty.TypeName.FixTypeName().IsCollectionTypeName())
         {
             return value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace("[ForcedNullableSuffix]", sourceProperty.IsValueType ? string.Empty : "!").Replace(".Select(x => x)", string.Empty);

--- a/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
+++ b/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
@@ -183,13 +183,14 @@ public class AddCopyConstructorComponent : IPipelineComponent<IConcreteTypeBuild
         var sourceExpression = metadata.GetStringValue(MetadataNames.CustomBuilderSourceExpression, PlaceholderNames.NamePlaceholder);
         if (sourceProperty.TypeName.FixTypeName().IsCollectionTypeName())
         {
-            return value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace(".Select(x => x)", string.Empty);
+            return value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace("[ForcedNullableSuffix]", sourceProperty.IsValueType ? string.Empty : "!").Replace(".Select(x => x)", string.Empty);
         }
 
         return value
             .Replace($"source.{PlaceholderNames.SourceExpressionPlaceholder}", $"{sourceExpression.Replace(PlaceholderNames.NamePlaceholder, "source." + sourceProperty.Name)}")
             .Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name)
-            .Replace("[NullableSuffix]", sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes));
+            .Replace("[NullableSuffix]", sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes))
+            .Replace("[ForcedNullableSuffix]", string.IsNullOrEmpty(sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes)) ? string.Empty : "!");
     }
 
     private static string CreateBuilderClassCopyConstructorChainCall(IType instance, PipelineSettings settings)

--- a/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
+++ b/src/ClassFramework.Pipelines/Builder/Components/AddCopyConstructorComponent.cs
@@ -3,23 +3,27 @@
 public class AddCopyConstructorComponentBuilder : IBuilderComponentBuilder
 {
     private readonly IFormattableStringParser _formattableStringParser;
+    private readonly ICsharpExpressionDumper _csharpExpressionDumper;
 
-    public AddCopyConstructorComponentBuilder(IFormattableStringParser formattableStringParser)
+    public AddCopyConstructorComponentBuilder(IFormattableStringParser formattableStringParser, ICsharpExpressionDumper csharpExpressionDumper)
     {
         _formattableStringParser = formattableStringParser.IsNotNull(nameof(formattableStringParser));
+        _csharpExpressionDumper = csharpExpressionDumper.IsNotNull(nameof(csharpExpressionDumper));
     }
 
     public IPipelineComponent<IConcreteTypeBuilder, BuilderContext> Build()
-        => new AddCopyConstructorComponent(_formattableStringParser);
+        => new AddCopyConstructorComponent(_formattableStringParser, _csharpExpressionDumper);
 }
 
 public class AddCopyConstructorComponent : IPipelineComponent<IConcreteTypeBuilder, BuilderContext>
 {
     private readonly IFormattableStringParser _formattableStringParser;
+    private readonly ICsharpExpressionDumper _csharpExpressionDumper;
 
-    public AddCopyConstructorComponent(IFormattableStringParser formattableStringParser)
+    public AddCopyConstructorComponent(IFormattableStringParser formattableStringParser, ICsharpExpressionDumper csharpExpressionDumper)
     {
         _formattableStringParser = formattableStringParser.IsNotNull(nameof(formattableStringParser));
+        _csharpExpressionDumper = csharpExpressionDumper.IsNotNull(nameof(csharpExpressionDumper));
     }
 
     public Result<IConcreteTypeBuilder> Process(PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
@@ -167,7 +171,7 @@ public class AddCopyConstructorComponent : IPipelineComponent<IConcreteTypeBuild
         return result;
     }
 
-    private static string? GetSourceExpression(string? value, Property sourceProperty, PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
+    private string? GetSourceExpression(string? value, Property sourceProperty, PipelineContext<IConcreteTypeBuilder, BuilderContext> context)
     {
         if (value is null || !value.Contains(PlaceholderNames.SourceExpressionPlaceholder))
         {
@@ -182,16 +186,18 @@ public class AddCopyConstructorComponent : IPipelineComponent<IConcreteTypeBuild
         var sourceExpression = context.Context
             .GetMappingMetadata(sourceProperty.TypeName)
             .GetStringValue(MetadataNames.CustomBuilderSourceExpression, PlaceholderNames.NamePlaceholder);
+
         if (sourceProperty.TypeName.FixTypeName().IsCollectionTypeName())
         {
-            return value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace("[ForcedNullableSuffix]", sourceProperty.IsValueType ? string.Empty : "!").Replace(".Select(x => x)", string.Empty);
+            return value.Replace(PlaceholderNames.SourceExpressionPlaceholder, $"{sourceProperty.Name}.Select(x => {sourceExpression})").Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace("[ForcedNullableSuffix]", string.Empty).Replace(".Select(x => x)", string.Empty);
         }
 
+        var suffix = sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes, _csharpExpressionDumper, context.Context);
         return value
             .Replace($"source.{PlaceholderNames.SourceExpressionPlaceholder}", $"{sourceExpression.Replace(PlaceholderNames.NamePlaceholder, "source." + sourceProperty.Name)}")
             .Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name)
-            .Replace("[NullableSuffix]", sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes))
-            .Replace("[ForcedNullableSuffix]", string.IsNullOrEmpty(sourceProperty.GetSuffix(context.Context.Settings.EnableNullableReferenceTypes)) ? string.Empty : "!");
+            .Replace("[NullableSuffix]", suffix)
+            .Replace("[ForcedNullableSuffix]", string.IsNullOrEmpty(suffix) ? string.Empty : "!");
     }
 
     private static string CreateBuilderClassCopyConstructorChainCall(IType instance, PipelineSettings settings)

--- a/src/ClassFramework.Pipelines/Builder/Components/AddPropertiesComponent.cs
+++ b/src/ClassFramework.Pipelines/Builder/Components/AddPropertiesComponent.cs
@@ -82,7 +82,7 @@ public class AddPropertiesComponent : IPipelineComponent<IConcreteTypeBuilder, B
     {
         if (property.HasBackingFieldOnBuilder(context.Settings))
         {
-            yield return new StringCodeStatementBuilder().WithStatement($"_{property.Name.ToPascalCase(context.FormatProvider.ToCultureInfo())} = value{property.GetNullCheckSuffix("value", context.Settings.AddNullChecks)};");
+            yield return new StringCodeStatementBuilder().WithStatement($"_{property.Name.ToPascalCase(context.FormatProvider.ToCultureInfo())} = value{property.GetNullCheckSuffix("value", context.Settings.AddNullChecks, context.SourceModel)};");
             if (context.Settings.CreateAsObservable)
             {
                 yield return new StringCodeStatementBuilder().WithStatement($"HandlePropertyChanged(nameof({property.Name}));");

--- a/src/ClassFramework.Pipelines/Builder/PlaceholderProcessors/BuilderPipelinePlaceholderProcessor.cs
+++ b/src/ClassFramework.Pipelines/Builder/PlaceholderProcessors/BuilderPipelinePlaceholderProcessor.cs
@@ -27,7 +27,7 @@ public class BuilderPipelinePlaceholderProcessor : IPlaceholderProcessor
                 return Result.Success(string.Empty);
             }
 
-            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
+            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formattableStringParser, parentChildContext.ParentContext.Context, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
         }
 
         return Result.Continue<string>();

--- a/src/ClassFramework.Pipelines/Builder/PlaceholderProcessors/BuilderPipelinePlaceholderProcessor.cs
+++ b/src/ClassFramework.Pipelines/Builder/PlaceholderProcessors/BuilderPipelinePlaceholderProcessor.cs
@@ -27,7 +27,7 @@ public class BuilderPipelinePlaceholderProcessor : IPlaceholderProcessor
                 return Result.Success(string.Empty);
             }
 
-            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
+            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
         }
 
         return Result.Continue<string>();

--- a/src/ClassFramework.Pipelines/BuilderExtension/PlaceholderProcessors/BuilderInterfacePipelinePlaceholderProcessor.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/PlaceholderProcessors/BuilderInterfacePipelinePlaceholderProcessor.cs
@@ -27,7 +27,7 @@ public class BuilderInterfacePipelinePlaceholderProcessor : IPlaceholderProcesso
                 return Result.Success("instance.");
             }
 
-            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext.ParentContext.Context, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
+            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formattableStringParser, parentChildContext.ParentContext.Context, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
         }
 
         return Result.Continue<string>();

--- a/src/ClassFramework.Pipelines/BuilderExtension/PlaceholderProcessors/BuilderInterfacePipelinePlaceholderProcessor.cs
+++ b/src/ClassFramework.Pipelines/BuilderExtension/PlaceholderProcessors/BuilderInterfacePipelinePlaceholderProcessor.cs
@@ -27,7 +27,7 @@ public class BuilderInterfacePipelinePlaceholderProcessor : IPlaceholderProcesso
                 return Result.Success("instance.");
             }
 
-            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext.ParentContext.Context, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
+            return parentChildContext.ParentContext.Context.GetBuilderPlaceholderProcessorResultForParentChildContext(value, formatProvider, formattableStringParser, parentChildContext.ParentContext.Context, parentChildContext.ParentContext.Context.SourceModel, parentChildContext.ChildContext, parentChildContext.ParentContext.Context.SourceModel, _pipelinePlaceholderProcessors);
         }
 
         return Result.Continue<string>();

--- a/src/ClassFramework.Pipelines/Builders/PipelineBuilders.template.generated.cs
+++ b/src/ClassFramework.Pipelines/Builders/PipelineBuilders.template.generated.cs
@@ -147,7 +147,7 @@ namespace ClassFramework.Pipelines.Builders
             _metadata = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Pipelines.Builders.MetadataBuilder>();
             _sourceNamespace = source.SourceNamespace;
             _targetNamespace = source.TargetNamespace;
-            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder()!)) _metadata.Add(item);
+            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder())) _metadata.Add(item);
         }
 
         public NamespaceMappingBuilder()
@@ -1146,7 +1146,7 @@ namespace ClassFramework.Pipelines.Builders
             _isForAbstractBuilder = source.IsForAbstractBuilder;
             _nameFormatString = source.NameFormatString;
             _namespaceFormatString = source.NamespaceFormatString;
-            if (source.NamespaceMappings is not null) foreach (var item in source.NamespaceMappings.Select(x => x.ToBuilder()!)) _namespaceMappings.Add(item);
+            if (source.NamespaceMappings is not null) foreach (var item in source.NamespaceMappings.Select(x => x.ToBuilder())) _namespaceMappings.Add(item);
             _builderNewCollectionTypeName = source.BuilderNewCollectionTypeName;
             _entityNewCollectionTypeName = source.EntityNewCollectionTypeName;
             _nonCollectionInitializationStatementFormatString = source.NonCollectionInitializationStatementFormatString;
@@ -1157,7 +1157,7 @@ namespace ClassFramework.Pipelines.Builders
             _setterVisibility = source.SetterVisibility;
             _toBuilderFormatString = source.ToBuilderFormatString;
             _toTypedBuilderFormatString = source.ToTypedBuilderFormatString;
-            if (source.TypenameMappings is not null) foreach (var item in source.TypenameMappings.Select(x => x.ToBuilder()!)) _typenameMappings.Add(item);
+            if (source.TypenameMappings is not null) foreach (var item in source.TypenameMappings.Select(x => x.ToBuilder())) _typenameMappings.Add(item);
             _useBaseClassFromSourceModel = source.UseBaseClassFromSourceModel;
             _useExceptionThrowIfNull = source.UseExceptionThrowIfNull;
             _validateArguments = source.ValidateArguments;
@@ -1658,7 +1658,7 @@ namespace ClassFramework.Pipelines.Builders
             _metadata = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Pipelines.Builders.MetadataBuilder>();
             _sourceTypeName = source.SourceTypeName;
             _targetTypeName = source.TargetTypeName;
-            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder()!)) _metadata.Add(item);
+            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder())) _metadata.Add(item);
         }
 
         public TypenameMappingBuilder()

--- a/src/ClassFramework.Pipelines/Builders/PipelineBuilders.template.generated.cs
+++ b/src/ClassFramework.Pipelines/Builders/PipelineBuilders.template.generated.cs
@@ -147,7 +147,7 @@ namespace ClassFramework.Pipelines.Builders
             _metadata = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Pipelines.Builders.MetadataBuilder>();
             _sourceNamespace = source.SourceNamespace;
             _targetNamespace = source.TargetNamespace;
-            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder())) _metadata.Add(item);
+            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder()!)) _metadata.Add(item);
         }
 
         public NamespaceMappingBuilder()
@@ -160,7 +160,7 @@ namespace ClassFramework.Pipelines.Builders
 
         public ClassFramework.Pipelines.NamespaceMapping Build()
         {
-            return new ClassFramework.Pipelines.NamespaceMapping(SourceNamespace, TargetNamespace, Metadata.Select(x => x.Build()).ToList().AsReadOnly());
+            return new ClassFramework.Pipelines.NamespaceMapping(SourceNamespace, TargetNamespace, Metadata.Select(x => x.Build()!).ToList().AsReadOnly());
         }
 
         partial void SetDefaultValues();
@@ -1113,7 +1113,7 @@ namespace ClassFramework.Pipelines.Builders
             _addSetters = source.AddSetters;
             _allowGenerationWithoutProperties = source.AllowGenerationWithoutProperties;
             if (source.AttributeInitializers is not null) foreach (var item in source.AttributeInitializers) _attributeInitializers.Add(item);
-            _baseClass = source.BaseClass?.ToBuilder();
+            _baseClass = source.BaseClass?.ToBuilder()!;
             _baseClassBuilderNameSpace = source.BaseClassBuilderNameSpace;
             _builderExtensionsCollectionCopyStatementFormatString = source.BuilderExtensionsCollectionCopyStatementFormatString;
             _builderExtensionsNameFormatString = source.BuilderExtensionsNameFormatString;
@@ -1146,7 +1146,7 @@ namespace ClassFramework.Pipelines.Builders
             _isForAbstractBuilder = source.IsForAbstractBuilder;
             _nameFormatString = source.NameFormatString;
             _namespaceFormatString = source.NamespaceFormatString;
-            if (source.NamespaceMappings is not null) foreach (var item in source.NamespaceMappings.Select(x => x.ToBuilder())) _namespaceMappings.Add(item);
+            if (source.NamespaceMappings is not null) foreach (var item in source.NamespaceMappings.Select(x => x.ToBuilder()!)) _namespaceMappings.Add(item);
             _builderNewCollectionTypeName = source.BuilderNewCollectionTypeName;
             _entityNewCollectionTypeName = source.EntityNewCollectionTypeName;
             _nonCollectionInitializationStatementFormatString = source.NonCollectionInitializationStatementFormatString;
@@ -1157,7 +1157,7 @@ namespace ClassFramework.Pipelines.Builders
             _setterVisibility = source.SetterVisibility;
             _toBuilderFormatString = source.ToBuilderFormatString;
             _toTypedBuilderFormatString = source.ToTypedBuilderFormatString;
-            if (source.TypenameMappings is not null) foreach (var item in source.TypenameMappings.Select(x => x.ToBuilder())) _typenameMappings.Add(item);
+            if (source.TypenameMappings is not null) foreach (var item in source.TypenameMappings.Select(x => x.ToBuilder()!)) _typenameMappings.Add(item);
             _useBaseClassFromSourceModel = source.UseBaseClassFromSourceModel;
             _useExceptionThrowIfNull = source.UseExceptionThrowIfNull;
             _validateArguments = source.ValidateArguments;
@@ -1197,7 +1197,7 @@ namespace ClassFramework.Pipelines.Builders
 
         public ClassFramework.Pipelines.PipelineSettings Build()
         {
-            return new ClassFramework.Pipelines.PipelineSettings(AddBackingFields, AddCopyConstructor, AddFullConstructor, AddMethodNameFormatString, AddNullChecks, AddPublicParameterlessConstructor, AddSetters, AllowGenerationWithoutProperties, AttributeInitializers, BaseClass?.Build(), BaseClassBuilderNameSpace, BuilderExtensionsCollectionCopyStatementFormatString, BuilderExtensionsNameFormatString, BuilderExtensionsNamespaceFormatString, BuilderNameFormatString, BuilderNamespaceFormatString, BuildMethodName, BuildTypedMethodName, CollectionCopyStatementFormatString, CollectionInitializationStatementFormatString, CollectionTypeName, CopyAttributePredicate, CopyAttributes, CopyInterfacePredicate, CopyInterfaces, CopyMethodPredicate, CopyMethods, InheritFromInterfaces, CreateAsObservable, CreateConstructors, CreateRecord, EnableBuilderInheritance, EnableInheritance, EnableNullableReferenceTypes, EntityNameFormatString, EntityNamespaceFormatString, InheritanceComparisonDelegate, InheritanceComparisonDelegateForReflection, IsAbstract, IsForAbstractBuilder, NameFormatString, NamespaceFormatString, NamespaceMappings.Select(x => x.Build()).ToList().AsReadOnly(), BuilderNewCollectionTypeName, EntityNewCollectionTypeName, NonCollectionInitializationStatementFormatString, CreateAsPartial, SetDefaultValuesInEntityConstructor, SetDefaultValuesMethodName, SetMethodNameFormatString, SetterVisibility, ToBuilderFormatString, ToTypedBuilderFormatString, TypenameMappings.Select(x => x.Build()).ToList().AsReadOnly(), UseBaseClassFromSourceModel, UseExceptionThrowIfNull, ValidateArguments, UseDefaultValueAttributeValuesForBuilderInitialization);
+            return new ClassFramework.Pipelines.PipelineSettings(AddBackingFields, AddCopyConstructor, AddFullConstructor, AddMethodNameFormatString, AddNullChecks, AddPublicParameterlessConstructor, AddSetters, AllowGenerationWithoutProperties, AttributeInitializers, BaseClass?.Build()!, BaseClassBuilderNameSpace, BuilderExtensionsCollectionCopyStatementFormatString, BuilderExtensionsNameFormatString, BuilderExtensionsNamespaceFormatString, BuilderNameFormatString, BuilderNamespaceFormatString, BuildMethodName, BuildTypedMethodName, CollectionCopyStatementFormatString, CollectionInitializationStatementFormatString, CollectionTypeName, CopyAttributePredicate, CopyAttributes, CopyInterfacePredicate, CopyInterfaces, CopyMethodPredicate, CopyMethods, InheritFromInterfaces, CreateAsObservable, CreateConstructors, CreateRecord, EnableBuilderInheritance, EnableInheritance, EnableNullableReferenceTypes, EntityNameFormatString, EntityNamespaceFormatString, InheritanceComparisonDelegate, InheritanceComparisonDelegateForReflection, IsAbstract, IsForAbstractBuilder, NameFormatString, NamespaceFormatString, NamespaceMappings.Select(x => x.Build()!).ToList().AsReadOnly(), BuilderNewCollectionTypeName, EntityNewCollectionTypeName, NonCollectionInitializationStatementFormatString, CreateAsPartial, SetDefaultValuesInEntityConstructor, SetDefaultValuesMethodName, SetMethodNameFormatString, SetterVisibility, ToBuilderFormatString, ToTypedBuilderFormatString, TypenameMappings.Select(x => x.Build()!).ToList().AsReadOnly(), UseBaseClassFromSourceModel, UseExceptionThrowIfNull, ValidateArguments, UseDefaultValueAttributeValuesForBuilderInitialization);
         }
 
         partial void SetDefaultValues();
@@ -1658,7 +1658,7 @@ namespace ClassFramework.Pipelines.Builders
             _metadata = new System.Collections.ObjectModel.ObservableCollection<ClassFramework.Pipelines.Builders.MetadataBuilder>();
             _sourceTypeName = source.SourceTypeName;
             _targetTypeName = source.TargetTypeName;
-            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder())) _metadata.Add(item);
+            if (source.Metadata is not null) foreach (var item in source.Metadata.Select(x => x.ToBuilder()!)) _metadata.Add(item);
         }
 
         public TypenameMappingBuilder()
@@ -1671,7 +1671,7 @@ namespace ClassFramework.Pipelines.Builders
 
         public ClassFramework.Pipelines.TypenameMapping Build()
         {
-            return new ClassFramework.Pipelines.TypenameMapping(SourceTypeName, TargetTypeName, Metadata.Select(x => x.Build()).ToList().AsReadOnly());
+            return new ClassFramework.Pipelines.TypenameMapping(SourceTypeName, TargetTypeName, Metadata.Select(x => x.Build()!).ToList().AsReadOnly());
         }
 
         partial void SetDefaultValues();

--- a/src/ClassFramework.Pipelines/Entity/Components/AddPropertiesComponent.cs
+++ b/src/ClassFramework.Pipelines/Entity/Components/AddPropertiesComponent.cs
@@ -79,7 +79,7 @@ public class AddPropertiesComponent : IPipelineComponent<IConcreteTypeBuilder, E
     {
         if (context.Settings.AddBackingFields || context.Settings.CreateAsObservable)
         {
-            yield return new StringCodeStatementBuilder().WithStatement($"_{property.Name.ToPascalCase(context.FormatProvider.ToCultureInfo())} = value{property.GetNullCheckSuffix("value", context.Settings.AddNullChecks)};");
+            yield return new StringCodeStatementBuilder().WithStatement($"_{property.Name.ToPascalCase(context.FormatProvider.ToCultureInfo())} = value{property.GetNullCheckSuffix("value", context.Settings.AddNullChecks, context.SourceModel)};");
             if (context.Settings.CreateAsObservable)
             {
                 yield return new StringCodeStatementBuilder().WithStatement($"HandlePropertyChanged(nameof({property.Name}));");

--- a/src/ClassFramework.Pipelines/Extensions/EnumerableOfMetadataExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/EnumerableOfMetadataExtensions.cs
@@ -29,7 +29,7 @@ public static class EnumerableOfMetadataExtensions
     {
         defaultValueDelegate = defaultValueDelegate.IsNotNull(nameof(defaultValueDelegate));
 
-        var metadataItem = metadata.FirstOrDefault(md => md.Name == metadataName);
+        var metadataItem = metadata.LastOrDefault(md => md.Name == metadataName);
 
         if (metadataItem is null)
         {

--- a/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PipelineContextExtensions.cs
@@ -108,7 +108,10 @@ public static class PipelineContextExtensions
         }
         else
         {
-            return value!.Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name).Replace("[NullableSuffix]", suffix);
+            return value!
+                .Replace(PlaceholderNames.NamePlaceholder, sourceProperty.Name)
+                .Replace("[NullableSuffix]", suffix)
+                .Replace("[ForcedNullableSuffix]", string.IsNullOrEmpty(suffix) ? string.Empty : "!");
         }
     }
 
@@ -116,7 +119,7 @@ public static class PipelineContextExtensions
         => collectionInitializer
             .Replace("[Type]", sourceProperty.TypeName.FixTypeName().WithoutProcessedGenerics())
             .Replace("[Generics]", sourceProperty.TypeName.FixTypeName().GetProcessedGenericArguments(addBrackets: true))
-            .Replace("[Expression]", $"{sourceProperty.Name}{suffix}.Select(x => {value!.Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty)})");
+            .Replace("[Expression]", $"{sourceProperty.Name}{suffix}.Select(x => {value!.Replace(PlaceholderNames.NamePlaceholder, "x").Replace("[NullableSuffix]", string.Empty).Replace("[ForcedNullableSuffix]", sourceProperty.IsValueType ? string.Empty : "!")})");
 
     private static string GetBuilderPocoCloseSign(bool poco)
         => poco

--- a/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
@@ -25,7 +25,7 @@ public static class PropertyExtensions
 
         var md = context
             .GetMappingMetadata(property.TypeName)
-            .FirstOrDefault(x => x.Name == MetadataNames.CustomBuilderDefaultValue);
+            .LastOrDefault(x => x.Name == MetadataNames.CustomBuilderDefaultValue);
 
         if (md is not null && md.Value is not null)
         {

--- a/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
@@ -220,8 +220,19 @@ public static class PropertyExtensions
         );
     }
 
-    public static string GetSuffix(this Property source, bool enableNullableReferenceTypes)
-        => source.IsNullable(enableNullableReferenceTypes) && !source.IsValueType && !source.TypeName.FixTypeName().IsCollectionTypeName()
+    public static string GetSuffix<T>(this Property source, bool enableNullableReferenceTypes, ICsharpExpressionDumper csharpExpressionDumper, ContextBase<T> context)
+        =>
+        (
+            source.IsNullable(enableNullableReferenceTypes)
+            && !source.IsValueType
+            && !source.TypeName.FixTypeName().IsCollectionTypeName()
+        )
+        ||
+        (
+            !source.TypeName.IsCollectionTypeName()
+            && !source.IsValueType
+            && source.GetDefaultValue(csharpExpressionDumper, source.TypeName.FixTypeName(), context).StartsWith("default(")
+        )
             ? "?"
             : string.Empty;
 }

--- a/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
+++ b/src/ClassFramework.Pipelines/Extensions/PropertyExtensions.cs
@@ -42,9 +42,16 @@ public static class PropertyExtensions
         return typeName.GetDefaultValue(property.IsNullable, property.IsValueType, context.Settings.EnableNullableReferenceTypes);
     }
 
-    public static string GetNullCheckSuffix(this Property property, string name, bool addNullChecks)
+    public static string GetNullCheckSuffix(this Property property, string name, bool addNullChecks, IType sourceModel)
     {
-        if (!addNullChecks || property.IsNullable || property.IsValueType)
+        name = name.IsNotNull(nameof(name));
+        sourceModel = sourceModel.IsNotNull(nameof(sourceModel));
+
+        // note that for now, we assume that a generic type argument should not be included in argument null checks...
+        // this might be the case (for example there is a constraint on class), but this is not supported yet
+        var isGenericArgument = sourceModel.GenericTypeArguments.Contains(property.TypeName);
+
+        if (!addNullChecks || property.IsNullable || property.IsValueType || isGenericArgument)
         {
             return string.Empty;
         }

--- a/src/ClassFramework.Pipelines/Shared/PlaceholderProcessors/PropertyProcessor.cs
+++ b/src/ClassFramework.Pipelines/Shared/PlaceholderProcessors/PropertyProcessor.cs
@@ -52,7 +52,7 @@ public class PropertyProcessor : IPipelinePlaceholderProcessor, IPlaceholderProc
             "ParentTypeName.GenericArgumentsWithBrackets" => Result.Success(propertyContext.SourceModel.ParentTypeFullName.GetClassName().GetProcessedGenericArguments(addBrackets: true)),
             "ParentTypeName.GenericArgumentsWithoutBrackets" => Result.Success(propertyContext.SourceModel.ParentTypeFullName.GetClassName().GetProcessedGenericArguments(addBrackets: false)),
             "DefaultValue" => formattableStringParser.Parse(propertyContext.SourceModel.GetDefaultValue(_csharpExpressionDumper, typeName, propertyContext), formatProvider, propertyContext),
-            "NullableSuffix" => Result.Success(propertyContext.SourceModel.GetSuffix(propertyContext.Settings.EnableNullableReferenceTypes)),
+            "NullableSuffix" => Result.Success(propertyContext.SourceModel.GetSuffix(propertyContext.Settings.EnableNullableReferenceTypes, _csharpExpressionDumper, propertyContext)),
             "BuilderAddMethodName" => formattableStringParser.Parse(propertyContext.Settings.AddMethodNameFormatString, formatProvider, propertyContext),
             _ => Result.Continue<string>()
         };

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -450,13 +450,13 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                             new MetadataBuilder().WithValue("I{TypeName.ClassName}Builder").WithName(MetadataNames.CustomBuilderInterfaceName),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions" && Array.Exists(x.GetInterfaces(), IsAbstractType)
                                 ? $"new {CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}.{x.GetEntityClassName()}Builder([Name])"
-                                : "[Name][NullableSuffix].ToBuilder()").WithName(MetadataNames.CustomBuilderSourceExpression),
+                                : "[Name][NullableSuffix].ToBuilder()[ForcedNullableSuffix]").WithName(MetadataNames.CustomBuilderSourceExpression),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions" && IsAbstractType(x)
                                 ? new Literal($"default({CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}.{x.GetEntityClassName()}Builder)", null)
                                 : new Literal($"new {CoreNamespace}.Builders{ReplaceStart(x.Namespace ?? string.Empty, $"{CodeGenerationRootNamespace}.Models", false)}.{x.GetEntityClassName()}Builder()", null)).WithName(MetadataNames.CustomBuilderDefaultValue),
                             new MetadataBuilder().WithValue(x.Namespace != $"{CodeGenerationRootNamespace}.Models.Abstractions" && Array.Exists(x.GetInterfaces(), IsAbstractType)
-                                ? "[Name][NullableSuffix].BuildTyped()"
-                                : "[Name][NullableSuffix].Build()").WithName(MetadataNames.CustomBuilderMethodParameterExpression),
+                                ? "[Name][NullableSuffix].BuildTyped()[ForcedNullableSuffix]"
+                                : "[Name][NullableSuffix].Build()[ForcedNullableSuffix]").WithName(MetadataNames.CustomBuilderMethodParameterExpression),
                             new MetadataBuilder().WithName(MetadataNames.CustomEntityInterfaceTypeName).WithValue($"{ProjectName}.Abstractions.I{x.GetEntityClassName()}")
                         )
                 })


### PR DESCRIPTION
- Improved argument null checks in case of generic type arguments
- Changed semantics of typename and namespace metadata mapping a little bit, so it takes the last occurence in case of multiple occurences. This way, you can override default stuff easier
- Improved nullable prefix for properties that have a default value (i.e. default((T)) and it's a reference type. This fixes null reference exceptions on calling Build, when properties are null