### PR TITLE
Fix nullable annotations for value types

### DIFF
--- a/src/ClassFramework.Domain.Tests/Extensions/StringExtensionsTests.cs
+++ b/src/ClassFramework.Domain.Tests/Extensions/StringExtensionsTests.cs
@@ -572,15 +572,16 @@ public class StringExtensionsTests
     }
     
     [Theory]
-    [InlineData("System.String", false, false, "System.String")]
-    [InlineData("System.String", true, false, "System.String")]
-    [InlineData("System.String", true, true, "System.String?")]
-    [InlineData("System.String?", true, true, "System.String?")]
-    [InlineData("System.Nullable<System.Int32>", true, true, "System.Nullable<System.Int32>")]
-    public void AppendNullableAnnotation_Returns_Correct_Result(string typeName, bool isNullable, bool enableNullableReferenceTypes, string expectedResult)
+    [InlineData("System.String", false, false, false, "System.String")]
+    [InlineData("System.String", true, false, false, "System.String")]
+    [InlineData("System.String", true, true, false, "System.String?")]
+    [InlineData("System.String?", true, true, false, "System.String?")]
+    [InlineData("System.Nullable<System.Int32>", true, true, false, "System.Nullable<System.Int32>")]
+    [InlineData("System.Nullable<System.Int32>", true, false, true, "System.Nullable<System.Int32>")]
+    public void AppendNullableAnnotation_Returns_Correct_Result(string typeName, bool isNullable, bool enableNullableReferenceTypes, bool isValueType, string expectedResult)
     {
         // Act
-        var result = typeName.AppendNullableAnnotation(isNullable, enableNullableReferenceTypes);
+        var result = typeName.AppendNullableAnnotation(isNullable, enableNullableReferenceTypes, isValueType);
 
         // Assert
         result.Should().Be(expectedResult);

--- a/src/ClassFramework.Domain/Extensions/StringExtensions.cs
+++ b/src/ClassFramework.Domain/Extensions/StringExtensions.cs
@@ -373,12 +373,13 @@ public static class StringExtensions
 
     public static string AppendNullableAnnotation(this string instance,
                                                   bool isNullable,
-                                                  bool enableNullableReferenceTypes)
+                                                  bool enableNullableReferenceTypes,
+                                                  bool isValueType)
         => !string.IsNullOrEmpty(instance)
             && !instance.StartsWith(typeof(Nullable<>).WithoutGenerics())
             && !instance.EndsWith("?")
             && isNullable
-            && enableNullableReferenceTypes
+            && (isValueType || enableNullableReferenceTypes)
                 ? $"{instance}?"
                 : instance;
 

--- a/src/ClassFramework.TemplateFramework/ViewModels/FieldViewModel.cs
+++ b/src/ClassFramework.TemplateFramework/ViewModels/FieldViewModel.cs
@@ -18,7 +18,7 @@ public class FieldViewModel : AttributeContainerViewModelBase<Field>
     public string TypeName
         => GetModel().TypeName
             .GetCsharpFriendlyTypeName()
-            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext)
+            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext, Model.IsValueType)
             .AbbreviateNamespaces(GetContext().GetCsharpClassGeneratorSettings().IsNotNull(nameof(CsharpClassGeneratorSettings)).NamespacesToAbbreviate);
 
     public string Name

--- a/src/ClassFramework.TemplateFramework/ViewModels/MethodViewModel.cs
+++ b/src/ClassFramework.TemplateFramework/ViewModels/MethodViewModel.cs
@@ -8,7 +8,7 @@ public class MethodViewModel : MethodViewModelBase<Method>
     public string ReturnTypeName
         => GetModel().ReturnTypeName
             .GetCsharpFriendlyTypeName()
-            .AppendNullableAnnotation(Model!.ReturnTypeIsNullable, Settings.EnableNullableContext)
+            .AppendNullableAnnotation(Model!.ReturnTypeIsNullable, Settings.EnableNullableContext, Model.ReturnTypeIsValueType)
             .AbbreviateNamespaces(GetContext().GetCsharpClassGeneratorSettings().IsNotNull(nameof(CsharpClassGeneratorSettings)).NamespacesToAbbreviate)
             .WhenNullOrEmpty("void");
 

--- a/src/ClassFramework.TemplateFramework/ViewModels/ParameterViewModel.cs
+++ b/src/ClassFramework.TemplateFramework/ViewModels/ParameterViewModel.cs
@@ -34,7 +34,7 @@ public class ParameterViewModel : AttributeContainerViewModelBase<Parameter>
     public string TypeName
         => GetModel().TypeName
             .GetCsharpFriendlyTypeName()
-            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext)
+            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext, Model.IsValueType)
             .AbbreviateNamespaces(GetContext().GetCsharpClassGeneratorSettings().IsNotNull(nameof(CsharpClassGeneratorSettings)).NamespacesToAbbreviate);
 
     public string Name

--- a/src/ClassFramework.TemplateFramework/ViewModels/PropertyViewModel.cs
+++ b/src/ClassFramework.TemplateFramework/ViewModels/PropertyViewModel.cs
@@ -15,7 +15,7 @@ public class PropertyViewModel : AttributeContainerViewModelBase<Property>
     public string TypeName
         => GetModel().TypeName
             .GetCsharpFriendlyTypeName()
-            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext)
+            .AppendNullableAnnotation(Model!.IsNullable, Settings.EnableNullableContext, Model.IsValueType)
             .AbbreviateNamespaces(GetContext().GetCsharpClassGeneratorSettings().IsNotNull(nameof(CsharpClassGeneratorSettings)).NamespacesToAbbreviate);
 
     public string Name


### PR DESCRIPTION
Nullability is supported out of the box, even without nullable context, for value types.