### PR TITLE
Attribute improvements

### DIFF
--- a/src/ClassFramework.CodeGeneration/Models/IAttributeParameter.cs
+++ b/src/ClassFramework.CodeGeneration/Models/IAttributeParameter.cs
@@ -3,5 +3,5 @@
 internal interface IAttributeParameter
 {
     [Required(AllowEmptyStrings = true)] string Name { get; }
-    object Value { get; }
+    object? Value { get; }
 }

--- a/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
+++ b/src/ClassFramework.Domain/Builders/CoreBuilders.template.generated.cs
@@ -103,7 +103,7 @@ namespace ClassFramework.Domain.Builders
     {
         private string _name;
 
-        private object _value;
+        private object? _value;
 
         public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
 
@@ -121,7 +121,7 @@ namespace ClassFramework.Domain.Builders
             }
         }
 
-        public object Value
+        public object? Value
         {
             get
             {
@@ -129,7 +129,7 @@ namespace ClassFramework.Domain.Builders
             }
             set
             {
-                _value = value ?? throw new System.ArgumentNullException(nameof(value));
+                _value = value;
                 HandlePropertyChanged(nameof(Value));
             }
         }
@@ -144,7 +144,6 @@ namespace ClassFramework.Domain.Builders
         public AttributeParameterBuilder()
         {
             _name = string.Empty;
-            _value = new System.Object();
             SetDefaultValues();
         }
 
@@ -162,9 +161,8 @@ namespace ClassFramework.Domain.Builders
             return this;
         }
 
-        public ClassFramework.Domain.Builders.AttributeParameterBuilder WithValue(object value)
+        public ClassFramework.Domain.Builders.AttributeParameterBuilder WithValue(object? value)
         {
-            if (value is null) throw new System.ArgumentNullException(nameof(value));
             Value = value;
             return this;
         }

--- a/src/ClassFramework.Domain/CoreEntities.template.generated.cs
+++ b/src/ClassFramework.Domain/CoreEntities.template.generated.cs
@@ -50,12 +50,12 @@ namespace ClassFramework.Domain
             get;
         }
 
-        public object Value
+        public object? Value
         {
             get;
         }
 
-        public AttributeParameter(string name, object value)
+        public AttributeParameter(string name, object? value)
         {
             this.Name = name;
             this.Value = value;

--- a/src/ClassFramework.Pipelines/Builders/PipelineSettingsBuilder.cs
+++ b/src/ClassFramework.Pipelines/Builders/PipelineSettingsBuilder.cs
@@ -101,21 +101,18 @@ public partial class PipelineSettingsBuilder
 
             return new AttributeBuilder()
                 .WithName(x.GetType())
-                .AddParameters(ctor.GetParameters().Select(y => new AttributeParameterBuilder().WithName(y.Name).WithValue(GetValue(x, y.Name))))
+                .AddParameters(ctor.GetParameters().Select(y => new AttributeParameterBuilder().WithValue(GetValue(x, y.Name))))
                 .Build();
         });
     }
 
-    private object? GetValue(System.Attribute x, string name)
+    private static object? GetValue(System.Attribute sourceAttribute, string name)
     {
-        var type = x.GetType();
-        var prop = type.GetProperty(name.ToPascalCase(CultureInfo.InvariantCulture));
-        if (prop is not null)
-        {
-            return prop.GetValue(x);
-        }
+        var prop = sourceAttribute.GetType().GetProperty(name.ToPascalCase(CultureInfo.InvariantCulture));
 
-        return null;
+        return prop is not null
+            ? prop.GetValue(sourceAttribute)
+            : null;
     }
 
     private static ConstructorInfo? GetConstructor(Type type)

--- a/src/ClassFramework.Pipelines/Builders/PipelineSettingsBuilder.cs
+++ b/src/ClassFramework.Pipelines/Builders/PipelineSettingsBuilder.cs
@@ -82,8 +82,8 @@ public partial class PipelineSettingsBuilder
                 .Build()));
         AttributeInitializers.Add(x => GetInitializer<ValidationAttribute>(x, validationAttribute => Array.Exists(x.GetType().GetConstructors(), y => y.GetParameters().Length == 0)
             ? new AttributeBuilder().WithName(validationAttribute.GetType())
-                .AddParameters(ErrorMessage(validationAttribute)).
-                Build()
+                .AddParameters(ErrorMessage(validationAttribute))
+                .Build()
             : null));
         AttributeInitializers.Add(x => GetInitializer<DefaultValueAttribute>(x, defaultValueAttribute =>
             new AttributeBuilder().WithName(defaultValueAttribute.GetType())

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -296,7 +296,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                 : null)
             .Chain(x =>
             {
-                foreach (var initializer in GetAttributeInitializers())
+                foreach (var initializer in GetAttributeInitializers().Reverse())
                 {
                     x.AttributeInitializers.Insert(0, initializer);
                 }

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -98,6 +98,8 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual IEnumerable<Type> GetPureAbstractModels()
         => GetType().Assembly.GetTypes().Where(IsAbstractType);
 
+    protected virtual IEnumerable<AttributeInitializerDelegate> GetAttributeInitializers() => Enumerable.Empty<AttributeInitializerDelegate>();
+
     /// <summary>
     /// Gets the base typename, based on a derived class.
     /// </summary>
@@ -292,6 +294,13 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .AddAttributeInitializers(x => x is CsharpTypeNameAttribute csharpTypeNameAttribute
                 ? new AttributeBuilder().WithName(csharpTypeNameAttribute.GetType()).AddParameters(new AttributeParameterBuilder().WithValue(csharpTypeNameAttribute.TypeName)).Build()
                 : null)
+            .Chain(x =>
+            {
+                foreach (var initializer in GetAttributeInitializers())
+                {
+                    x.AttributeInitializers.Insert(0, initializer);
+                }
+            })
             .Build();
 
     private async Task<PipelineSettings> CreateEntityPipelineSettings(

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -98,8 +98,6 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual IEnumerable<Type> GetPureAbstractModels()
         => GetType().Assembly.GetTypes().Where(IsAbstractType);
 
-    protected virtual IEnumerable<AttributeInitializerDelegate> GetAttributeInitializers() => Enumerable.Empty<AttributeInitializerDelegate>();
-
     /// <summary>
     /// Gets the base typename, based on a derived class.
     /// </summary>
@@ -279,7 +277,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             ? validateArgumentsInConstructor
             : ArgumentValidationType.None;
 
-    private PipelineSettings CreateReflectionPipelineSettings()
+    protected virtual PipelineSettings CreateReflectionPipelineSettings()
         => new PipelineSettingsBuilder()
             .WithAllowGenerationWithoutProperties(AllowGenerationWithoutProperties)
             .WithCopyAttributes(CopyAttributes)
@@ -294,13 +292,6 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .AddAttributeInitializers(x => x is CsharpTypeNameAttribute csharpTypeNameAttribute
                 ? new AttributeBuilder().WithName(csharpTypeNameAttribute.GetType()).AddParameters(new AttributeParameterBuilder().WithValue(csharpTypeNameAttribute.TypeName)).Build()
                 : null)
-            .Chain(x =>
-            {
-                foreach (var initializer in GetAttributeInitializers().Reverse())
-                {
-                    x.AttributeInitializers.Insert(0, initializer);
-                }
-            })
             .Build();
 
     private async Task<PipelineSettings> CreateEntityPipelineSettings(


### PR DESCRIPTION
- Made CreateReflectionPipelineSettings configurable on C# class generator pipeline provider, so you can add custom attribute initializers
- Changed fallback on default attribute initializers, so we pick the one with the most number of constructor arguments
- Changed attribute parameter value to nullable, makes no sense to make it required (and initialize it with a new object() by default)