### PR TITLE
Upgrade TemplateFramework

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,3 +46,20 @@ E.g. System.Func<System.Object, System.Int32, System.Object?>
 Just create a delegate for this, and add this to the type mapping.
 
 If you still get errors, you could use the CsharpTypeNameAttribute to decorate your property/field/parameter.
+
+# Upgrading to version 0.19
+
+Most methods in the CsharpClassGeneratorPipelineCodeGenerationProviderBase class have wrapped their result in a Result<T> type.
+So, for example, IEnumerable<TypeBase> becomes Result<IEnumerable<TypeBase>>.
+
+For example, this code:
+```C#
+Task<IEnumerable<TypeBase>> GetModel()
+```
+
+has changed to:
+```C#
+Task<Result<IEnumerable<TypeBase>>>
+```
+
+This way, you can return errors and halt program flow with Result.Error instead of throwing exceptions.

--- a/src/ClassFramework.CodeGeneration/ClassFramework.CodeGeneration.csproj
+++ b/src/ClassFramework.CodeGeneration/ClassFramework.CodeGeneration.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.1.2" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetAbstractModels(), "ClassFramework.Domain.Builders", "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetAbstractModels(), "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractNonGenericBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractNonGenericBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetNonGenericBuilders(GetAbstractModels(), "ClassFramework.Domain.Builders", "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsBuildersExtensions(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Extensions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderExtensions(GetAbstractionsInterfaces(), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Extensions");
 
     public override string Path => "ClassFramework.Domain/Builders/Extensions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsBuildersExtensions(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Extensions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Extensions").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Builders/Extensions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsBuildersInterfaces(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderInterfaces(GetAbstractionsInterfaces(), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Abstractions");
 
     public override string Path => "ClassFramework.Domain/Builders/Abstractions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsBuildersInterfaces(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain.Builders.Abstractions", "ClassFramework.Domain.Abstractions", "ClassFramework.Domain.Builders.Abstractions").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Builders/Abstractions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsInterfaces(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain", "ClassFramework.Domain.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain", "ClassFramework.Domain.Abstractions").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Abstractions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/AbstractionsInterfaces.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class AbstractionsInterfaces(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "ClassFramework.Domain", "ClassFramework.Domain.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntityInterfaces(GetAbstractionsInterfaces(), "ClassFramework.Domain", "ClassFramework.Domain.Abstractions");
 
     public override string Path => "ClassFramework.Domain/Abstractions";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
@@ -23,10 +23,10 @@ public abstract class ClassFrameworkCSharpClassBase(IPipelineService pipelineSer
     //protected override string ToTypedBuilderFormatString => string.Empty;
     //protected override bool AddCopyConstructor => false;
 
-    protected async Task<TypeBase[]> GetPipelineModels()
+    protected async Task<Result<IEnumerable<TypeBase>>> GetPipelineModels()
         => await GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.Pipelines").ConfigureAwait(false);
 
-    protected async Task<TypeBase[]> GetTemplateFrameworkModels()
+    protected async Task<Result<IEnumerable<TypeBase>>> GetTemplateFrameworkModels()
         => await GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.TemplateFramework").ConfigureAwait(false);
 
     protected override bool SkipNamespaceOnTypenameMappings(string @namespace)

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/ClassFrameworkCSharpClassBase.cs
@@ -23,11 +23,11 @@ public abstract class ClassFrameworkCSharpClassBase(IPipelineService pipelineSer
     //protected override string ToTypedBuilderFormatString => string.Empty;
     //protected override bool AddCopyConstructor => false;
 
-    protected async Task<Result<IEnumerable<TypeBase>>> GetPipelineModels()
-        => await GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.Pipelines").ConfigureAwait(false);
+    protected Task<Result<IEnumerable<TypeBase>>> GetPipelineModels()
+        => GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.Pipelines");
 
-    protected async Task<Result<IEnumerable<TypeBase>>> GetTemplateFrameworkModels()
-        => await GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.TemplateFramework").ConfigureAwait(false);
+    protected Task<Result<IEnumerable<TypeBase>>> GetTemplateFrameworkModels()
+        => GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.TemplateFramework");
 
     protected override bool SkipNamespaceOnTypenameMappings(string @namespace)
         => @namespace.In($"{CodeGenerationRootNamespace}.Models.Pipelines",

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class CoreBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "ClassFramework.Domain.Builders", "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class CoreBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain.Builders", "ClassFramework.Domain").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class CoreEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetCoreModels(), "ClassFramework.Domain");
 
     public override string Path => "ClassFramework.Domain";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/CoreEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class CoreEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Domain";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
@@ -7,7 +7,7 @@ public class OverrideCodeStatementBuilders(IPipelineService pipelineService) : C
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.CodeStatements", "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
@@ -7,8 +7,8 @@ public class OverrideCodeStatementBuilders(IPipelineService pipelineService) : C
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetBuilders(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.CodeStatements", "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetBuilders(GetOverrideModels(typeof(ICodeStatementBase)), "ClassFramework.Domain.Builders.CodeStatements", "ClassFramework.Domain.CodeStatements");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementBuilders.cs
@@ -9,6 +9,6 @@ public class OverrideCodeStatementBuilders(IPipelineService pipelineService) : C
     protected override bool CreateAsObservable => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.CodeStatements", "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
@@ -6,8 +6,8 @@ public class OverrideCodeStatementEntities(IPipelineService pipelineService) : C
     public override string Path => "ClassFramework.Domain/CodeStatements";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetEntities(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetEntities(GetOverrideModels(typeof(ICodeStatementBase)), "ClassFramework.Domain.CodeStatements");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
@@ -8,6 +8,6 @@ public class OverrideCodeStatementEntities(IPipelineService pipelineService) : C
     protected override bool EnableEntityInheritance => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideCodeStatementEntities.cs
@@ -6,7 +6,7 @@ public class OverrideCodeStatementEntities(IPipelineService pipelineService) : C
     public override string Path => "ClassFramework.Domain/CodeStatements";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ICodeStatementBase), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(ICodeStatementBase)).ConfigureAwait(false), "ClassFramework.Domain.CodeStatements").ConfigureAwait(false);

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -7,8 +7,8 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ClassFrame
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetBuilders(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.Types", "ClassFramework.Domain.Types").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetBuilders(GetOverrideModels(typeof(ITypeBase)), "ClassFramework.Domain.Builders.Types", "ClassFramework.Domain.Types");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -9,6 +9,6 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ClassFrame
     protected override bool CreateAsObservable => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.Types", "ClassFramework.Domain.Types").ConfigureAwait(false);
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -7,7 +7,7 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ClassFrame
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Builders.Types", "ClassFramework.Domain.Types").ConfigureAwait(false);

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -6,8 +6,8 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ClassFrame
     public override string Path => "ClassFramework.Domain/Types";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetEntities(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Types").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetEntities(GetOverrideModels(typeof(ITypeBase)), "ClassFramework.Domain.Types");
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -8,6 +8,6 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ClassFrame
     protected override bool EnableEntityInheritance => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Types").ConfigureAwait(false);
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -6,7 +6,7 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ClassFrame
     public override string Path => "ClassFramework.Domain/Types";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(ITypeBase), "ClassFramework.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(ITypeBase)).ConfigureAwait(false), "ClassFramework.Domain.Types").ConfigureAwait(false);

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class PipelineBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines.Builders", "ClassFramework.Pipelines").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines.Builders", "ClassFramework.Pipelines").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Pipelines/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class PipelineBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines.Builders", "ClassFramework.Pipelines").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetPipelineModels(), "ClassFramework.Pipelines.Builders", "ClassFramework.Pipelines");
 
     public override string Path => "ClassFramework.Pipelines/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class PipelineEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetPipelineModels(), "ClassFramework.Pipelines");
 
     public override string Path => "ClassFramework.Pipelines";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/PipelineEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class PipelineEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetPipelineModels().ConfigureAwait(false), "ClassFramework.Pipelines").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.Pipelines";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class TemplateFrameworkBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework.Builders", "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework.Builders", "ClassFramework.TemplateFramework").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.TemplateFramework/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkBuilders.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkBuilders.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class TemplateFrameworkBuilders(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework.Builders", "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework.Builders", "ClassFramework.TemplateFramework");
 
     public override string Path => "ClassFramework.TemplateFramework/Builders";
 

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class TemplateFrameworkEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.CodeGeneration/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class TemplateFrameworkEntities(IPipelineService pipelineService) : ClassFrameworkCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.CodeGeneration/GlobalUsings.cs
+++ b/src/ClassFramework.CodeGeneration/GlobalUsings.cs
@@ -17,6 +17,7 @@ global using ClassFramework.TemplateFramework.Extensions;
 global using CrossCutting.Common;
 global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Extensions;
+global using CrossCutting.Common.Results;
 global using CrossCutting.Utilities.Parsers.Extensions;
 global using CsharpExpressionDumper.Core.Extensions;
 global using ExpressionFramework.Parser;

--- a/src/ClassFramework.TemplateFramework.Tests/ClassFramework.TemplateFramework.Tests.csproj
+++ b/src/ClassFramework.TemplateFramework.Tests/ClassFramework.TemplateFramework.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="1.1.2" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractBuilders.cs
@@ -2,7 +2,7 @@
 
 public class AbstractBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractBuilders.cs
@@ -2,7 +2,7 @@
 
 public class AbstractBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetAbstractModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractEntities.cs
@@ -2,7 +2,7 @@
 
 public class AbstractEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetAbstractModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractEntities.cs
@@ -2,7 +2,7 @@
 
 public class AbstractEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetAbstractModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractNonGenericBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractNonGenericBuilders.cs
@@ -2,7 +2,7 @@
 
 public class AbstractNonGenericBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetNonGenericBuilders(GetAbstractModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractNonGenericBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractNonGenericBuilders.cs
@@ -2,7 +2,7 @@
 
 public class AbstractNonGenericBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetNonGenericBuilders(await GetAbstractModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
@@ -2,7 +2,7 @@
 
 public class AbstractionsBuildersExtensions(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Extensions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Extensions").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders/Extensions";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersExtensions.cs
@@ -2,7 +2,7 @@
 
 public class AbstractionsBuildersExtensions(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Extensions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderExtensions(GetAbstractionsInterfaces(), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Extensions");
 
     public override string Path => "Test.Domain/Builders/Extensions";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class AbstractionsBuildersInterfaces(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Abstractions").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders/Abstractions";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsBuildersInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class AbstractionsBuildersInterfaces(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderInterfaces(GetAbstractionsInterfaces(), "Test.Domain.Builders.Abstractions", "Test.Domain.Abstractions", "Test.Domain.Builders.Abstractions");
 
     public override string Path => "Test.Domain/Builders/Abstractions";
 

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsInterfaces.cs
@@ -4,7 +4,7 @@ public class AbstractionsInterfaces(IPipelineService pipelineService) : Immutabl
 {
     public override string Path => "Test.Domain/Abstractions";
 
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain", "Test.Domain.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain", "Test.Domain.Abstractions").ConfigureAwait(false);
 
     protected override bool EnableEntityInheritance => true;
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/AbstractionsInterfaces.cs
@@ -4,7 +4,7 @@ public class AbstractionsInterfaces(IPipelineService pipelineService) : Immutabl
 {
     public override string Path => "Test.Domain/Abstractions";
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetAbstractionsInterfaces().ConfigureAwait(false), "Test.Domain", "Test.Domain.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntityInterfaces(GetAbstractionsInterfaces(), "Test.Domain", "Test.Domain.Abstractions");
 
     protected override bool EnableEntityInheritance => true;
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCSharpClassBase.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCSharpClassBase.cs
@@ -17,7 +17,7 @@ public abstract class ImmutableCSharpClassBase(IPipelineService pipelineService)
     protected override bool CopyInterfaces => true;
     protected override bool CreateCodeGenerationHeader => false;
 
-    protected async Task<TypeBase[]> GetTemplateFrameworkModels()
+    protected async Task<Result<IEnumerable<TypeBase>>> GetTemplateFrameworkModels()
         => await GetNonCoreModels($"{CodeGenerationRootNamespace}.Models.TemplateFramework").ConfigureAwait(false);
 
     protected override bool SkipNamespaceOnTypenameMappings(string @namespace)

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBaseClassErrorBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBaseClassErrorBuilders.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableCoreBaseClassErrorBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
+{
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "Test.Domain.Builders", "Test.Domain");
+
+    public override string Path => "Test.Domain/Builders";
+
+    protected override Task<Result<TypeBase>> GetBaseClass() => Task.FromResult(Result.Error<TypeBase>("Kaboom"));
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilderExtensions.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilderExtensions.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreBuilderExtensions(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Domain.Extensions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderExtensions(GetCoreModels(), "Test.Domain.Builders", "Test.Domain", "Test.Domain.Extensions");
 
     public override string Path => "Test.Domain/Extensions";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilderExtensions.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilderExtensions.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreBuilderExtensions(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderExtensions(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Domain.Extensions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderExtensions(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Domain.Extensions").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Extensions";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableCoreEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreErrorBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreErrorBuilders.cs
@@ -4,7 +4,7 @@ public class ImmutableCoreErrorBuilders(IPipelineService pipelineService) : Immu
 {
     protected override string SetMethodNameFormatString => "With{$property.Kaboom}";
 
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreErrorBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreErrorBuilders.cs
@@ -4,7 +4,7 @@ public class ImmutableCoreErrorBuilders(IPipelineService pipelineService) : Immu
 {
     protected override string SetMethodNameFormatString => "With{$property.Kaboom}";
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreModelErrorBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreModelErrorBuilders.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassFramework.TemplateFramework.Tests.CodeGenerationProviders;
+
+public class ImmutableCoreModelErrorBuilders(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
+{
+    protected override string SetMethodNameFormatString => "With{$property.Kaboom}";
+
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Error<IEnumerable<TypeBase>>("Kaboom"), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+
+    public override string Path => "Test.Domain/Builders";
+}

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreModelErrorBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableCoreModelErrorBuilders.cs
@@ -4,7 +4,7 @@ public class ImmutableCoreModelErrorBuilders(IPipelineService pipelineService) :
 {
     protected override string SetMethodNameFormatString => "With{$property.Kaboom}";
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Error<IEnumerable<TypeBase>>("Kaboom"), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(Task.FromResult(Result.Error<IEnumerable<TypeBase>>("Kaboom")), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilderInterfaces(GetCoreModels(), "Test.Domain.Builders", "Test.Domain", "Test.Abstractions");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesAbstractionsBuilderInterfaces(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilderInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilderInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesAbstractionsInterfaces(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntityInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesAbstractionsInterfaces.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesAbstractionsInterfaces(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntityInterfaces(await GetCoreModels().ConfigureAwait(false), "Test.Domain", "Test.Abstractions").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntityInterfaces(GetCoreModels(), "Test.Domain", "Test.Abstractions");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreBuilders(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreBuilders(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build())), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Task.FromResult(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()))), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreBuilders(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build())), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreEntities(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build())), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Task.FromResult(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()))), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreEntities(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Result.Success((await GetCoreModels().ConfigureAwait(false)).Value!.Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build())), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableInheritFromInterfacesCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableInheritFromInterfacesCoreEntities(IPipelineService pipelineService) : ImmutableInheritFromInterfacesCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities((await GetCoreModels().ConfigureAwait(false)).Select(x => x.ToBuilder().AddInterfaces($"Test.Domain.Abstractions.{x.Name}").Build()).ToArray(), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableNoToBuilderMethodCoreEntities(IPipelineService pipelineService) : ImmutableNoToBuilderMethodCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutableNoToBuilderMethodCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutableNoToBuilderMethodCoreEntities(IPipelineService pipelineService) : ImmutableNoToBuilderMethodCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutablePrivateSettersCoreBuilders(IPipelineService pipelineService) : ImmutablePrivateSettersCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ImmutablePrivateSettersCoreBuilders(IPipelineService pipelineService) : ImmutablePrivateSettersCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutablePrivateSettersCoreEntities(IPipelineService pipelineService) : ImmutablePrivateSettersCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ImmutablePrivateSettersCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ImmutablePrivateSettersCoreEntities(IPipelineService pipelineService) : ImmutablePrivateSettersCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedCSharpClassBase.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedCSharpClassBase.cs
@@ -25,7 +25,7 @@ public abstract class MappedCSharpClassBase(IPipelineService pipelineService) : 
             .AddMetadata(CreateTypenameMappingMetadata(typeof(IMyMappedType)));
     }
 
-    protected async Task<TypeBase[]> GetTypeNamedModels()
+    protected async Task<Result<IEnumerable<TypeBase>>> GetTypeNamedModels()
     => await GetNonCoreModels($"{CodeGenerationRootNamespace}.SomeNamespace").ConfigureAwait(false);
 
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeBuilders(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()]), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Task.FromResult(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()])), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeBuilders(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeBuilders.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeBuilders(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()]), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeEntities(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()]), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeEntities(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()], "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/MappedTypeEntities.cs
@@ -2,7 +2,7 @@
 
 public class MappedTypeEntities(IPipelineService pipelineService) : MappedCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()]), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(Task.FromResult(Result.Success<IEnumerable<TypeBase>>([new ClassBuilder().WithName("MyClass").AddProperties(new PropertyBuilder().WithName("MyProperty").WithType(typeof(IMyMappedType))).Build()])), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ObservableCoreBuilders(IPipelineService pipelineService) : ObservableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreBuilders.cs
@@ -2,7 +2,7 @@
 
 public class ObservableCoreBuilders(IPipelineService pipelineService) : ObservableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetBuilders(await GetCoreModels().ConfigureAwait(false), "Test.Domain.Builders", "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetBuilders(GetCoreModels(), "Test.Domain.Builders", "Test.Domain");
 
     public override string Path => "Test.Domain/Builders";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ObservableCoreEntities(IPipelineService pipelineService) : ObservableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/ObservableCoreEntities.cs
@@ -2,7 +2,7 @@
 
 public class ObservableCoreEntities(IPipelineService pipelineService) : ObservableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetCoreModels().ConfigureAwait(false), "Test.Domain").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetCoreModels(), "Test.Domain");
 
     public override string Path => "Test.Domain";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -6,7 +6,7 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ImmutableC
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Builders.Types", "Test.Domain.Types").ConfigureAwait(false);

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -8,6 +8,6 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ImmutableC
     protected override bool CreateAsObservable => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetBuilders(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Builders.Types", "Test.Domain.Types").ConfigureAwait(false);
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeBuilders.cs
@@ -6,8 +6,8 @@ public class OverrideTypeBuilders(IPipelineService pipelineService) : ImmutableC
 
     protected override bool EnableEntityInheritance => true;
     protected override bool CreateAsObservable => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(IAbstractBase), "Test.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetBuilders(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Builders.Types", "Test.Domain.Types").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetBuilders(GetOverrideModels(typeof(IAbstractBase)), "Test.Domain.Builders.Types", "Test.Domain.Types");
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -5,7 +5,7 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ImmutableC
     public override string Path => "Test.Domain/Types";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
+    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
 
     public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Types").ConfigureAwait(false);

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -5,8 +5,8 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ImmutableC
     public override string Path => "Test.Domain/Types";
 
     protected override bool EnableEntityInheritance => true;
-    protected override async Task<Result<TypeBase>> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
+    protected override Task<Result<TypeBase>> GetBaseClass() => CreateBaseClass(typeof(IAbstractBase), "Test.Domain");
 
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
-        => await GetEntities(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Types").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
+        => GetEntities(GetOverrideModels(typeof(IAbstractBase)), "Test.Domain.Types");
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/OverrideTypeEntities.cs
@@ -7,6 +7,6 @@ public class OverrideTypeEntities(IPipelineService pipelineService) : ImmutableC
     protected override bool EnableEntityInheritance => true;
     protected override async Task<TypeBase?> GetBaseClass() => await CreateBaseClass(typeof(IAbstractBase), "Test.Domain").ConfigureAwait(false);
 
-    public override async Task<IEnumerable<TypeBase>> GetModel()
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken)
         => await GetEntities(await GetOverrideModels(typeof(IAbstractBase)).ConfigureAwait(false), "Test.Domain.Types").ConfigureAwait(false);
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -2,7 +2,7 @@
 
 public class TemplateFrameworkEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<IEnumerable<TypeBase>> GetModel() => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/CodeGenerationProviders/TemplateFrameworkEntities.cs
@@ -2,7 +2,7 @@
 
 public class TemplateFrameworkEntities(IPipelineService pipelineService) : ImmutableCSharpClassBase(pipelineService)
 {
-    public override async Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => await GetEntities(await GetTemplateFrameworkModels().ConfigureAwait(false), "ClassFramework.TemplateFramework").ConfigureAwait(false);
+    public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => GetEntities(GetTemplateFrameworkModels(), "ClassFramework.TemplateFramework");
 
     public override string Path => "ClassFramework.TemplateFramework";
 }

--- a/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
+++ b/src/ClassFramework.TemplateFramework.Tests/IntegrationTests.cs
@@ -1685,7 +1685,7 @@ namespace Test.Domain.Builders
 
     private sealed class TestCodeGenerationProvider : CsharpClassGeneratorCodeGenerationProviderBase
     {
-        public override Task<IEnumerable<TypeBase>> GetModel() => Task.FromResult<IEnumerable<TypeBase>>(
+        public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<TypeBase>>(
         [
             new ClassBuilder()
                 .WithNamespace("MyNamespace")
@@ -1722,7 +1722,7 @@ namespace Test.Domain.Builders
         public override string LastGeneratedFilesFilename => string.Empty;
         public override Encoding Encoding => Encoding.UTF8;
 
-        public override Task<IEnumerable<TypeBase>> GetModel() => Task.FromResult<IEnumerable<TypeBase>>(
+        public override Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<TypeBase>>(
         [
             new InterfaceBuilder()
                 .WithName("IMyEntity")

--- a/src/ClassFramework.TemplateFramework/ClassFramework.TemplateFramework.csproj
+++ b/src/ClassFramework.TemplateFramework/ClassFramework.TemplateFramework.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="pauldeen79.TemplateFramework.Core" Version="1.1.2" />
-    <PackageReference Include="pauldeen79.TemplateFramework.TemplateProviders.ChildTemplateProvider" Version="1.1.2" />
+    <PackageReference Include="pauldeen79.TemplateFramework.Core" Version="2.0.0" />
+    <PackageReference Include="pauldeen79.TemplateFramework.TemplateProviders.ChildTemplateProvider" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorCodeGenerationProviderBase.cs
@@ -7,24 +7,32 @@ public abstract class CsharpClassGeneratorCodeGenerationProviderBase : ICodeGene
     public abstract string LastGeneratedFilesFilename { get; }
     public abstract Encoding Encoding { get; }
 
-    public Task<object?> CreateAdditionalParameters() => Task.FromResult(default(object?));
+    public Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken) => Task.FromResult(Result.Success(default(object?)));
 
     public Type GetGeneratorType() => typeof(CsharpClassGenerator);
 
-    public async Task<object?> CreateModel()
-        => new CsharpClassGeneratorViewModel
+    public async Task<Result<object?>> CreateModel(CancellationToken cancellationToken)
+    {
+        var modelResult = await GetModel(cancellationToken).ConfigureAwait(false);
+        if (!modelResult.IsSuccessful())
         {
-            Model = await GetModel().ConfigureAwait(false),
+            return modelResult.TryCast<object?>();
+        }
+
+        return Result.Success<object?>(new CsharpClassGeneratorViewModel
+        {
+            Model = modelResult.Value,
             Settings = Settings
             //Context is filled in base class, on the property setter of Context (propagated to Model)
-        };
+        });
+    }
 
     public IGenerationEnvironment CreateGenerationEnvironment()
         => Settings.GenerateMultipleFiles
             ? new MultipleStringContentBuilderEnvironment()
             : new StringBuilderEnvironment();
 
-    public abstract Task<IEnumerable<TypeBase>> GetModel();
+    public abstract Task<Result<IEnumerable<TypeBase>>> GetModel(CancellationToken cancellationToken);
     public abstract CsharpClassGeneratorSettings Settings { get; }
 
     protected virtual string CurrentNamespace => Path.Replace('/', '.');

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -595,19 +595,52 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     }
 
     private async Task<Result<TypeBase>> CreateBuilderClass(Result<TypeBase> typeBaseResult, string buildersNamespace, string entitiesNamespace)
-        => typeBaseResult.IsSuccessful()
-            ? await PipelineService.Process(new BuilderContext(typeBaseResult.Value!, await CreateBuilderPipelineSettings(buildersNamespace, entitiesNamespace).ConfigureAwait(false), Settings.CultureInfo)).ConfigureAwait(false)
-            : typeBaseResult;
+    {
+        if (!typeBaseResult.IsSuccessful())
+        {
+            return typeBaseResult;
+        }
+
+        var builderSettingsResult = await CreateBuilderPipelineSettings(buildersNamespace, entitiesNamespace).ConfigureAwait(false);
+        if (!builderSettingsResult.IsSuccessful())
+        {
+            return Result.Error<TypeBase>([builderSettingsResult], "Could not create builder settings, see inner results for details");
+        }
+
+        return await PipelineService.Process(new BuilderContext(typeBaseResult.Value!, builderSettingsResult.Value!, Settings.CultureInfo)).ConfigureAwait(false);
+    }
 
     private async Task<Result<TypeBase>> CreateBuilderExtensionsClass(Result<TypeBase> typeBaseResult, string buildersNamespace, string entitiesNamespace, string buildersExtensionsNamespace)
-        => typeBaseResult.IsSuccessful()
-            ? await PipelineService.Process(new BuilderExtensionContext(typeBaseResult.Value!, await CreateBuilderInterfacePipelineSettings(buildersNamespace, entitiesNamespace, buildersExtensionsNamespace).ConfigureAwait(false), Settings.CultureInfo)).ConfigureAwait(false)
-            : typeBaseResult;
+    {
+        if (!typeBaseResult.IsSuccessful())
+        {
+            return typeBaseResult;
+        }
+
+        var builderInterfaceSettingsResult = await CreateBuilderInterfacePipelineSettings(buildersNamespace, entitiesNamespace, buildersExtensionsNamespace).ConfigureAwait(false);
+        if (!builderInterfaceSettingsResult.IsSuccessful())
+        {
+            return Result.Error<TypeBase>([builderInterfaceSettingsResult], "Could not create builder interface settings, see inner results for details");
+        }
+
+        return await PipelineService.Process(new BuilderExtensionContext(typeBaseResult.Value!, builderInterfaceSettingsResult.Value!, Settings.CultureInfo)).ConfigureAwait(false);
+    }
 
     private async Task<Result<TypeBase>> CreateNonGenericBuilderClass(Result<TypeBase> typeBaseResult, string buildersNamespace, string entitiesNamespace)
-        => typeBaseResult.IsSuccessful()
-            ? await PipelineService.Process(new BuilderContext(typeBaseResult.Value!, (await CreateBuilderPipelineSettings(buildersNamespace, entitiesNamespace).ConfigureAwait(false)).ToBuilder().WithIsForAbstractBuilder().Build(), Settings.CultureInfo)).ConfigureAwait(false)
-            : typeBaseResult;
+    {
+        if (!typeBaseResult.IsSuccessful())
+        {
+            return typeBaseResult;
+        }
+
+        var builderSettings = await CreateBuilderPipelineSettings(buildersNamespace, entitiesNamespace).ConfigureAwait(false);
+        if (!builderSettings.IsSuccessful())
+        {
+            return Result.Error<TypeBase>([builderSettings], "Could not create builder settings, see inner results for details");
+        }
+
+        return await PipelineService.Process(new BuilderContext(typeBaseResult.Value!, builderSettings.Value!.ToBuilder().WithIsForAbstractBuilder().Build(), Settings.CultureInfo)).ConfigureAwait(false);
+    }
 
     private bool? GetOverrideAddNullChecks()
     {

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -169,7 +169,9 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         Guard.IsNotNull(entitiesNamespace);
         Guard.IsNotNull(interfacesNamespace);
 
-        return await ProcessModelsResult(modelsResultTask, async x =>
+        var buildersResultTask = GetBuilders(modelsResultTask, buildersNamespace, entitiesNamespace);
+
+        return await ProcessModelsResult(buildersResultTask, async x =>
         {
             return await CreateInterface(Result.Success(x), interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0).ConfigureAwait(false);
         }, "builder interfaces").ConfigureAwait(false);

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -110,13 +110,15 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         return ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(x => CreateEntity(x, entitiesNamespace)), "entities");
     }
 
-    protected Task<Result<IEnumerable<TypeBase>>> GetEntityInterfaces(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace, string interfacesNamespace)
+    protected async Task<Result<IEnumerable<TypeBase>>> GetEntityInterfaces(Task<Result<IEnumerable<TypeBase>>> modelsResultTask, string entitiesNamespace, string interfacesNamespace)
     {
-        Guard.IsNotNull(modelsResult);
+        Guard.IsNotNull(modelsResultTask);
         Guard.IsNotNull(entitiesNamespace);
         Guard.IsNotNull(interfacesNamespace);
 
-        return ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(async x => await CreateInterface(await CreateEntity(x, entitiesNamespace).ConfigureAwait(false), interfacesNamespace, string.Empty, true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == ToBuilderFormatString && t.Interfaces.Count == 0).ConfigureAwait(false)), "interfaces");
+        var modelsResult = await modelsResultTask.ConfigureAwait(false);
+
+        return await ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(async x => await CreateInterface(await CreateEntity(x, entitiesNamespace).ConfigureAwait(false), interfacesNamespace, string.Empty, true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == ToBuilderFormatString && t.Interfaces.Count == 0).ConfigureAwait(false)), "interfaces").ConfigureAwait(false);
     }
 
     protected Task<Result<IEnumerable<TypeBase>>> GetBuilders(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace)

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -102,14 +102,6 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual IEnumerable<Type> GetPureAbstractModels()
         => GetType().Assembly.GetTypes().Where(IsAbstractType);
 
-    /// <summary>
-    /// Gets the base typename, based on a derived class.
-    /// </summary>
-    /// <param name="className">The typename to get the base classname from.</param>
-    /// <returns>Base classname when found, otherwise string.Empty</returns>
-    protected string GetEntityClassName(string className)
-        => Array.Find(GetCustomBuilderTypes(), x => className.EndsWith(x, StringComparison.InvariantCulture)) ?? string.Empty;
-
     protected async Task<Result<IEnumerable<TypeBase>>> GetEntities(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace)
     {
         Guard.IsNotNull(modelsResult);

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -121,7 +121,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         }
 
         var entitiesResults = (await modelsResult.Value!.SelectAsync(x => CreateEntity(x, entitiesNamespace)).ConfigureAwait(false)).ToArray();
-        return Result.Aggregate(entitiesResults, Result.Success(entitiesResults.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create entities, see inner results for details"));
+        return Result.Aggregate(entitiesResults, Result.Success(entitiesResults.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create entities. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetEntityInterfaces(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace, string interfacesNamespace)
@@ -136,7 +136,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         }
 
         var interfaceResults = (await modelsResult.Value!.SelectAsync(async x => await CreateInterface(await CreateEntity(x, entitiesNamespace).ConfigureAwait(false), interfacesNamespace, string.Empty, true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == ToBuilderFormatString && t.Interfaces.Count == 0).ConfigureAwait(false)).ConfigureAwait(false)).ToArray();
-        return Result.Aggregate(interfaceResults, Result.Success(interfaceResults.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create interfaces, see inner results for details"));
+        return Result.Aggregate(interfaceResults, Result.Success(interfaceResults.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create interfaces. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetBuilders(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace)
@@ -157,7 +157,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             return await CreateBuilderClass(entityResult, buildersNamespace, entitiesNamespace).ConfigureAwait(false);
         }).ConfigureAwait(false);
 
-        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builders, see inner results for details"));
+        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builders. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetBuilderExtensions(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace, string buildersExtensionsNamespace)
@@ -179,7 +179,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             return await CreateBuilderExtensionsClass(interfaceResult.TryCast<TypeBase>(), buildersNamespace, entitiesNamespace, buildersExtensionsNamespace).ConfigureAwait(false);
         }).ConfigureAwait(false);
 
-        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builder extensions, see inner results for details"));
+        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builder extensions. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetNonGenericBuilders(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace)
@@ -200,7 +200,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             return await CreateNonGenericBuilderClass(typeBaseResult, buildersNamespace, entitiesNamespace).ConfigureAwait(false);
         }).ConfigureAwait(false);
 
-        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create non generic builders, see inner results for details"));
+        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create non generic builders. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetBuilderInterfaces(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace, string interfacesNamespace)
@@ -226,7 +226,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             return await CreateInterface(Result.Success(x), interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0).ConfigureAwait(false);
         }).ConfigureAwait(false);
 
-        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builder interfaces, see inner results for details"));
+        return Result.Aggregate(results, Result.Success(results.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create builder interfaces. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetCoreModels()
@@ -237,7 +237,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .ConfigureAwait(false))
             .ToArray();
 
-        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create core models, see inner results for details"));
+        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create core models. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetNonCoreModels(string @namespace)
@@ -248,7 +248,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .ConfigureAwait(false))
             .ToArray();
 
-        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create non core models, see inner results for details"));
+        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create non core models. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetAbstractionsInterfaces()
@@ -259,7 +259,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .ConfigureAwait(false))
             .ToArray();
 
-        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create abstract interfaces, see inner results for details"));
+        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create abstract interfaces. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetAbstractModels()
@@ -269,7 +269,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .ConfigureAwait(false))
             .ToArray();
 
-        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create abstract models, see inner results for details"));
+        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create abstract models. See the inner results for more details."));
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetOverrideModels(Type abstractType)
@@ -282,7 +282,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
                 .ConfigureAwait(false))
                 .ToArray();
 
-        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create override models, see inner results for details"));
+        return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create override models. See the inner results for more details."));
     }
 
     protected async Task<Result<TypeBase>> CreateBaseClass(Type type, string @namespace)

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -102,21 +102,21 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
     protected virtual IEnumerable<Type> GetPureAbstractModels()
         => GetType().Assembly.GetTypes().Where(IsAbstractType);
 
-    protected async Task<Result<IEnumerable<TypeBase>>> GetEntities(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace)
+    protected Task<Result<IEnumerable<TypeBase>>> GetEntities(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace)
     {
         Guard.IsNotNull(modelsResult);
         Guard.IsNotNull(entitiesNamespace);
 
-        return await ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(x => CreateEntity(x, entitiesNamespace)), "entities").ConfigureAwait(false);
+        return ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(x => CreateEntity(x, entitiesNamespace)), "entities");
     }
 
-    protected async Task<Result<IEnumerable<TypeBase>>> GetEntityInterfaces(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace, string interfacesNamespace)
+    protected Task<Result<IEnumerable<TypeBase>>> GetEntityInterfaces(Result<IEnumerable<TypeBase>> modelsResult, string entitiesNamespace, string interfacesNamespace)
     {
         Guard.IsNotNull(modelsResult);
         Guard.IsNotNull(entitiesNamespace);
         Guard.IsNotNull(interfacesNamespace);
 
-        return await ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(async x => await CreateInterface(await CreateEntity(x, entitiesNamespace).ConfigureAwait(false), interfacesNamespace, string.Empty, true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == ToBuilderFormatString && t.Interfaces.Count == 0).ConfigureAwait(false)), "interfaces").ConfigureAwait(false);
+        return ProcessModelsResult(modelsResult, modelsResult.Value!.SelectAsync(async x => await CreateInterface(await CreateEntity(x, entitiesNamespace).ConfigureAwait(false), interfacesNamespace, string.Empty, true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == ToBuilderFormatString && t.Interfaces.Count == 0).ConfigureAwait(false)), "interfaces");
     }
 
     protected async Task<Result<IEnumerable<TypeBase>>> GetBuilders(Result<IEnumerable<TypeBase>> modelsResult, string buildersNamespace, string entitiesNamespace)
@@ -194,6 +194,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         Guard.IsNotNull(interfacesNamespace);
 
         var buildersResult = await GetBuilders(modelsResult, buildersNamespace, entitiesNamespace).ConfigureAwait(false);
+
         return await ProcessModelsResult(buildersResult, buildersResult.Value!.SelectAsync(async x =>
         {
             return await CreateInterface(Result.Success(x), interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0).ConfigureAwait(false);

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -276,9 +276,9 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         Guard.IsNotNull(abstractType);
 
         var modelsResult = await GetType().Assembly.GetTypes()
-                .Where(x => x.IsInterface && Array.Exists(x.GetInterfaces(), y => y == abstractType))
-                .SelectAsync(GetModel)
-                .ConfigureAwait(false);
+            .Where(x => x.IsInterface && Array.Exists(x.GetInterfaces(), y => y == abstractType))
+            .SelectAsync(GetModel)
+            .ConfigureAwait(false);
 
         return Result.Aggregate(modelsResult, Result.Success(modelsResult.Select(x => x.Value!)), x => Result.Error<IEnumerable<TypeBase>>(x, "Could not create override models. See the inner results for more details."));
     }

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -169,12 +169,12 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
         Guard.IsNotNull(entitiesNamespace);
         Guard.IsNotNull(interfacesNamespace);
 
-        var buildersResultTask = GetBuilders(modelsResultTask, buildersNamespace, entitiesNamespace);
-
-        return await ProcessModelsResult(buildersResultTask, async x =>
-        {
-            return await CreateInterface(Result.Success(x), interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0).ConfigureAwait(false);
-        }, "builder interfaces").ConfigureAwait(false);
+        return await ProcessModelsResult
+        (
+            GetBuilders(modelsResultTask, buildersNamespace, entitiesNamespace),
+            async x => await CreateInterface(Result.Success(x), interfacesNamespace, BuilderCollectionType.WithoutGenerics(), true, "I{$class.Name}", (t, m) => InheritFromInterfaces && m.Name == BuildMethodName && t.Interfaces.Count == 0).ConfigureAwait(false),
+            "builder interfaces"
+        ).ConfigureAwait(false);
     }
 
     protected static async Task<Result<IEnumerable<TypeBase>>> ProcessModelsResult(Task<Result<IEnumerable<TypeBase>>> modelsResultTask, Func<TypeBase, Task<Result<TypeBase>>> successTask, string resultType)

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -279,7 +279,10 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
 
         var reflectionSettings = CreateReflectionPipelineSettings();
         var typeBaseResult = await PipelineService.Process(new ReflectionContext(type, reflectionSettings, Settings.CultureInfo)).ConfigureAwait(false);
-        var typeBase = typeBaseResult.GetValueOrThrow();
+        if (!typeBaseResult.IsSuccessful())
+        {
+            return Result.Error<TypeBase>([typeBaseResult], "Could not create base class, see inner results for details");
+        }
 
         var entitySettings = new PipelineSettingsBuilder()
             .WithAddSetters(AddSetters)
@@ -318,7 +321,7 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
             .WithUseExceptionThrowIfNull(UseExceptionThrowIfNull)
             .Build();
 
-        return await PipelineService.Process(new EntityContext(typeBase, entitySettings, Settings.CultureInfo)).ConfigureAwait(false);
+        return await PipelineService.Process(new EntityContext(typeBaseResult.Value!, entitySettings, Settings.CultureInfo)).ConfigureAwait(false);
     }
 
     private static bool DefaultCopyAttributePredicate(Domain.Attribute attribute)

--- a/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
+++ b/src/ClassFramework.TemplateFramework/CodeGenerationProviders/CsharpClassGeneratorPipelineCodeGenerationProviderBase.cs
@@ -192,18 +192,8 @@ public abstract class CsharpClassGeneratorPipelineCodeGenerationProviderBase : C
 
         var modelsResult = await modelsResultTask.ConfigureAwait(false);
 
-        return await ProcessModelsResult(modelsResult, Task.FromResult(Result.Continue<PipelineSettings>()), async settings => await modelsResult.Value!.SelectAsync(x => successTask(x)).ConfigureAwait(false), resultType).ConfigureAwait(false);
+        return await ProcessModelsResult(modelsResult, Task.FromResult(Result.Continue<PipelineSettings>()), async _ => await modelsResult.Value!.SelectAsync(x => successTask(x)).ConfigureAwait(false), resultType).ConfigureAwait(false);
     }
-
-    //protected static async Task<Result<IEnumerable<TypeBase>>> ProcessModelsResult(Task<Result<IEnumerable<TypeBase>>> modelsResultTask, Task<Result<PipelineSettings>> settingsTask, Func<TypeBase, Task<Result<TypeBase>>> successTask, string resultType)
-    //{
-    //    Guard.IsNotNull(modelsResultTask);
-    //    Guard.IsNotNull(settingsTask);
-
-    //    var modelsResult = await modelsResultTask.ConfigureAwait(false);
-
-    //    return await ProcessModelsResult(modelsResult, settingsTask, async _ => await modelsResult.Value!.SelectAsync(x => successTask(x)).ConfigureAwait(false), resultType).ConfigureAwait(false);
-    //}
 
     protected static Task<Result<IEnumerable<TypeBase>>> ProcessModelsResult(Result<IEnumerable<TypeBase>> modelsResult, Task<Result<PipelineSettings>> settingsTask, Func<PipelineSettings, Task<IEnumerable<Result<TypeBase>>>> successTask, string resultType)
     {


### PR DESCRIPTION
The new major version of TemplateFramework uses results wrapped in a Result<T> class, so you don't have to throw exceptions in your code. 